### PR TITLE
Remove the extends clause

### DIFF
--- a/util/interface.js
+++ b/util/interface.js
@@ -160,7 +160,6 @@ const typeToInterface = (type, ignoredTypes) => {
 
     if (possibleTypes.length) {
       additionalInfo = generateTypeDeclaration(type.description, generateTypeName(type.name), possibleTypes.join(' | '))
-      interfaceDeclaration += ` extends ${possibleTypes.join(', ')}`;
     }
   }
 


### PR DESCRIPTION
Since no interface/union should extend the types that fullfils them.

This causes problems when the schema is defined like this

interface Node {
  id: ID!
}

type Dog implements Node{
id: ID!
type: DogEnum
}

type Cat implements Node{
id: ID!
type: CatEnum
}