### PR TITLE
Remove the extends clause

### DIFF
--- a/test/data/expectedInterfaces.js
+++ b/test/data/expectedInterfaces.js
@@ -94,7 +94,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   /*
     description: An object with an ID
   */
-  interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IPerson, IFilm {
+  interface INode {
     __typename: string;
     id: string;
   }

--- a/test/data/expectedNamespace.js
+++ b/test/data/expectedNamespace.js
@@ -97,7 +97,7 @@ declare namespace GQL {
   /*
     description: An object with an ID
   */
-  interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IPerson, IFilm {
+  interface INode {
     __typename: string;
     id: string;
   }

--- a/test/data/ignoredPerson.js
+++ b/test/data/ignoredPerson.js
@@ -96,7 +96,7 @@ declare namespace StarWars {
   /*
     description: An object with an ID
   */
-  interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IFilm {
+  interface INode {
     __typename: string;
     id: string;
   }

--- a/test/data/ignoredPersonInterfaces.js
+++ b/test/data/ignoredPersonInterfaces.js
@@ -93,7 +93,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   /*
     description: An object with an ID
   */
-  interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IFilm {
+  interface INode {
     __typename: string;
     id: string;
   }

--- a/test/data/starWarsNamespace.js
+++ b/test/data/starWarsNamespace.js
@@ -97,7 +97,7 @@ declare namespace StarWars {
   /*
     description: An object with an ID
   */
-  interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IPerson, IFilm {
+  interface INode {
     __typename: string;
     id: string;
   }

--- a/util/interface.js
+++ b/util/interface.js
@@ -160,7 +160,6 @@ const typeToInterface = (type, ignoredTypes) => {
 
     if (possibleTypes.length) {
       additionalInfo = generateTypeDeclaration(type.description, generateTypeName(type.name), possibleTypes.join(' | '))
-      interfaceDeclaration += ` extends ${possibleTypes.join(', ')}`;
     }
   }
 


### PR DESCRIPTION
Since no interface/union should extend the types that fullfils them.

This causes problems when the schema is defined like this

interface Node {
id: ID!
}

type Dog implements Node{
id: ID!
type: DogEnum
}

type Cat implements Node{
id: ID!
type: CatEnum
}