### PR TITLE
Adds a CLI flag before applying nullability checks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Master
+
+Adds support for nullability attributes inside derived interfaces - [@neelance](https://github.com/neelance) [@orta](https://github.com/orta) [#34](https://github.com/avantcredit/gql2ts/pull/34).
+Note that for older versions of TypeScript, you can use the CLI flag `--legacy` to get output without nullability references.
+
+
 ## 0.4.0
 - Stop extending `GraphQLInterface`s with their possible types. (thanks [@tomaba](https://github.com/tomaba)) [#25](https://github.com/avantcredit/gql2ts/pull/25)
   - Previously, if two possible types implement a similar field, but with a different type it will cause an error

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ Options:
   -o --output-file [outputFile]      name for ouput file, defaults to graphqlInterfaces.d.ts
   -n --namespace [namespace]         name for the namespace, defaults to "GQL"
   -i --ignored-types <ignoredTypes>  names of types to ignore (comma delimited)
+  -l --legacy                        Use TypeScript 1.x annotation
 ```
 
 ### Examples

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ program
   .option('-o --output-file [outputFile]', 'name for ouput file, defaults to graphqlInterfaces.d.ts', 'graphqlInterfaces.d.ts')
   .option('-n --namespace [namespace]', 'name for the namespace, defaults to "GQL"', 'GQL')
   .option('-i --ignored-types <ignoredTypes>', 'names of types to ignore (comma delimited)', v => v.split(','), [])
+  .option('-l --legacy', 'Use TypeScript 1.x annotation', false)
   .action((fileName, options) => {
     let schema = fileIO.readFile(fileName);
 

--- a/test/data/expectedEnum.js
+++ b/test/data/expectedEnum.js
@@ -22,7 +22,7 @@ declare namespace GQL {
   */
   interface IQuery {
     __typename: string;
-    colorEnum: IColorEnum;
+    colorEnum: IColorEnum | null;
   }
 
   /*

--- a/test/data/expectedEnumInterfaces.js
+++ b/test/data/expectedEnumInterfaces.js
@@ -19,7 +19,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IQuery {
     __typename: string;
-    colorEnum: IColorEnum;
+    colorEnum: IColorEnum | null;
   }
 
   /*

--- a/test/data/expectedInterfaces.js
+++ b/test/data/expectedInterfaces.js
@@ -19,19 +19,19 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IRoot {
     __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    person: IPerson;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
+    allFilms: IFilmsConnection | null;
+    film: IFilm | null;
+    allPeople: IPeopleConnection | null;
+    person: IPerson | null;
+    allPlanets: IPlanetsConnection | null;
+    planet: IPlanet | null;
+    allSpecies: ISpeciesConnection | null;
+    species: ISpecies | null;
+    allStarships: IStarshipsConnection | null;
+    starship: IStarship | null;
+    allVehicles: IVehiclesConnection | null;
+    vehicle: IVehicle | null;
+    node: Node | null;
   }
 
   /*
@@ -40,9 +40,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -52,8 +52,8 @@ module.exports = `  interface IGraphQLResponseRoot {
     __typename: string;
     hasNextPage: boolean;
     hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
+    startCursor: string | null;
+    endCursor: string | null;
   }
 
   /*
@@ -61,7 +61,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -70,19 +70,19 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilm {
     __typename: string;
-    title: string;
-    episodeID: number;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
+    title: string | null;
+    episodeID: number | null;
+    openingCrawl: string | null;
+    director: string | null;
+    producers: Array<string> | null;
+    releaseDate: string | null;
+    speciesConnection: IFilmSpeciesConnection | null;
+    starshipConnection: IFilmStarshipsConnection | null;
+    vehicleConnection: IFilmVehiclesConnection | null;
+    characterConnection: IFilmCharactersConnection | null;
+    planetConnection: IFilmPlanetsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -105,19 +105,19 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPlanet {
     __typename: string;
-    name: string;
-    diameter: number;
-    rotationPeriod: number;
-    orbitalPeriod: number;
-    gravity: string;
-    population: number;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    diameter: number | null;
+    rotationPeriod: number | null;
+    orbitalPeriod: number | null;
+    gravity: string | null;
+    population: number | null;
+    climates: Array<string> | null;
+    terrains: Array<string> | null;
+    surfaceWater: number | null;
+    residentConnection: IPlanetResidentsConnection | null;
+    filmConnection: IPlanetFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -127,9 +127,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPlanetResidentsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: number;
-    residents: Array<IPerson>;
+    edges: Array<IPlanetResidentsEdge> | null;
+    totalCount: number | null;
+    residents: Array<IPerson> | null;
   }
 
   /*
@@ -137,7 +137,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPlanetResidentsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -146,21 +146,21 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPerson {
     __typename: string;
-    name: string;
-    birthYear: string;
-    eyeColor: string;
-    gender: string;
-    hairColor: string;
-    height: number;
-    mass: number;
-    skinColor: string;
-    homeworld: IPlanet;
-    filmConnection: IPersonFilmsConnection;
-    species: ISpecies;
-    starshipConnection: IPersonStarshipsConnection;
-    vehicleConnection: IPersonVehiclesConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    birthYear: string | null;
+    eyeColor: string | null;
+    gender: string | null;
+    hairColor: string | null;
+    height: number | null;
+    mass: number | null;
+    skinColor: string | null;
+    homeworld: IPlanet | null;
+    filmConnection: IPersonFilmsConnection | null;
+    species: ISpecies | null;
+    starshipConnection: IPersonStarshipsConnection | null;
+    vehicleConnection: IPersonVehiclesConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -170,9 +170,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPersonFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPersonFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -180,7 +180,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPersonFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -189,20 +189,20 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface ISpecies {
     __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: number;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    classification: string | null;
+    designation: string | null;
+    averageHeight: number | null;
+    averageLifespan: number | null;
+    eyeColors: Array<string> | null;
+    hairColors: Array<string> | null;
+    skinColors: Array<string> | null;
+    language: string | null;
+    homeworld: IPlanet | null;
+    personConnection: ISpeciesPeopleConnection | null;
+    filmConnection: ISpeciesFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -212,9 +212,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface ISpeciesPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: number;
-    people: Array<IPerson>;
+    edges: Array<ISpeciesPeopleEdge> | null;
+    totalCount: number | null;
+    people: Array<IPerson> | null;
   }
 
   /*
@@ -222,7 +222,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface ISpeciesPeopleEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -232,9 +232,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface ISpeciesFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<ISpeciesFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -242,7 +242,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface ISpeciesFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -252,9 +252,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPersonStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IPersonStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -262,7 +262,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPersonStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -271,23 +271,23 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IStarship {
     __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    hyperdriveRating: number;
-    MGLT: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    starshipClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    hyperdriveRating: number | null;
+    MGLT: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IStarshipPilotsConnection | null;
+    filmConnection: IStarshipFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -297,9 +297,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IStarshipPilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: number;
-    pilots: Array<IPerson>;
+    edges: Array<IStarshipPilotsEdge> | null;
+    totalCount: number | null;
+    pilots: Array<IPerson> | null;
   }
 
   /*
@@ -307,7 +307,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IStarshipPilotsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -317,9 +317,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IStarshipFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IStarshipFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -327,7 +327,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IStarshipFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -337,9 +337,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPersonVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IPersonVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -347,7 +347,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPersonVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -356,21 +356,21 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IVehicle {
     __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    vehicleClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IVehiclePilotsConnection | null;
+    filmConnection: IVehicleFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -380,9 +380,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IVehiclePilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: number;
-    pilots: Array<IPerson>;
+    edges: Array<IVehiclePilotsEdge> | null;
+    totalCount: number | null;
+    pilots: Array<IPerson> | null;
   }
 
   /*
@@ -390,7 +390,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IVehiclePilotsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -400,9 +400,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IVehicleFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IVehicleFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -410,7 +410,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IVehicleFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -420,9 +420,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPlanetFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPlanetFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -430,7 +430,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPlanetFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -440,9 +440,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmSpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<IFilmSpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -450,7 +450,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmSpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -460,9 +460,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IFilmStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -470,7 +470,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -480,9 +480,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IFilmVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -490,7 +490,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -500,9 +500,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmCharactersConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: number;
-    characters: Array<IPerson>;
+    edges: Array<IFilmCharactersEdge> | null;
+    totalCount: number | null;
+    characters: Array<IPerson> | null;
   }
 
   /*
@@ -510,7 +510,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmCharactersEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -520,9 +520,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IFilmPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -530,7 +530,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -540,9 +540,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: number;
-    people: Array<IPerson>;
+    edges: Array<IPeopleEdge> | null;
+    totalCount: number | null;
+    people: Array<IPerson> | null;
   }
 
   /*
@@ -550,7 +550,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPeopleEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -560,9 +560,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -570,7 +570,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -580,9 +580,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface ISpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<ISpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -590,7 +590,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface ISpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -600,9 +600,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -610,7 +610,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -620,9 +620,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -630,6 +630,6 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }`

--- a/test/data/expectedLegacyInterfaces.js
+++ b/test/data/expectedLegacyInterfaces.js
@@ -1,0 +1,635 @@
+module.exports = `  interface IGraphQLResponseRoot {
+    data?: IRoot;
+    errors?: Array<IGraphQLResponseError>;
+  }
+
+  interface IGraphQLResponseError {
+    message: string;            // Required for all errors
+    locations?: Array<IGraphQLResponseErrorLocation>;
+    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+  }
+
+  interface IGraphQLResponseErrorLocation {
+    line: number;
+    column: number;
+  }
+
+  /*
+    description: null
+  */
+  interface IRoot {
+    __typename: string;
+    allFilms: IFilmsConnection;
+    film: IFilm;
+    allPeople: IPeopleConnection;
+    person: IPerson;
+    allPlanets: IPlanetsConnection;
+    planet: IPlanet;
+    allSpecies: ISpeciesConnection;
+    species: ISpecies;
+    allStarships: IStarshipsConnection;
+    starship: IStarship;
+    allVehicles: IVehiclesConnection;
+    vehicle: IVehicle;
+    node: Node;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IFilmsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IFilmsEdge>;
+    totalCount: number;
+    films: Array<IFilm>;
+  }
+
+  /*
+    description: Information about pagination in a connection.
+  */
+  interface IPageInfo {
+    __typename: string;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string;
+    endCursor: string;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IFilmsEdge {
+    __typename: string;
+    node: IFilm;
+    cursor: string;
+  }
+
+  /*
+    description: A single film.
+  */
+  interface IFilm {
+    __typename: string;
+    title: string;
+    episodeID: number;
+    openingCrawl: string;
+    director: string;
+    producers: Array<string>;
+    releaseDate: string;
+    speciesConnection: IFilmSpeciesConnection;
+    starshipConnection: IFilmStarshipsConnection;
+    vehicleConnection: IFilmVehiclesConnection;
+    characterConnection: IFilmCharactersConnection;
+    planetConnection: IFilmPlanetsConnection;
+    created: string;
+    edited: string;
+    id: string;
+  }
+
+  /*
+    description: An object with an ID
+  */
+  type Node = IPlanet | ISpecies | IStarship | IVehicle | IPerson | IFilm;
+
+  /*
+    description: An object with an ID
+  */
+  interface INode {
+    __typename: string;
+    id: string;
+  }
+
+  /*
+    description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
+0 ABY.
+  */
+  interface IPlanet {
+    __typename: string;
+    name: string;
+    diameter: number;
+    rotationPeriod: number;
+    orbitalPeriod: number;
+    gravity: string;
+    population: number;
+    climates: Array<string>;
+    terrains: Array<string>;
+    surfaceWater: number;
+    residentConnection: IPlanetResidentsConnection;
+    filmConnection: IPlanetFilmsConnection;
+    created: string;
+    edited: string;
+    id: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IPlanetResidentsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IPlanetResidentsEdge>;
+    totalCount: number;
+    residents: Array<IPerson>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IPlanetResidentsEdge {
+    __typename: string;
+    node: IPerson;
+    cursor: string;
+  }
+
+  /*
+    description: An individual person or character within the Star Wars universe.
+  */
+  interface IPerson {
+    __typename: string;
+    name: string;
+    birthYear: string;
+    eyeColor: string;
+    gender: string;
+    hairColor: string;
+    height: number;
+    mass: number;
+    skinColor: string;
+    homeworld: IPlanet;
+    filmConnection: IPersonFilmsConnection;
+    species: ISpecies;
+    starshipConnection: IPersonStarshipsConnection;
+    vehicleConnection: IPersonVehiclesConnection;
+    created: string;
+    edited: string;
+    id: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IPersonFilmsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IPersonFilmsEdge>;
+    totalCount: number;
+    films: Array<IFilm>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IPersonFilmsEdge {
+    __typename: string;
+    node: IFilm;
+    cursor: string;
+  }
+
+  /*
+    description: A type of person or character within the Star Wars Universe.
+  */
+  interface ISpecies {
+    __typename: string;
+    name: string;
+    classification: string;
+    designation: string;
+    averageHeight: number;
+    averageLifespan: number;
+    eyeColors: Array<string>;
+    hairColors: Array<string>;
+    skinColors: Array<string>;
+    language: string;
+    homeworld: IPlanet;
+    personConnection: ISpeciesPeopleConnection;
+    filmConnection: ISpeciesFilmsConnection;
+    created: string;
+    edited: string;
+    id: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface ISpeciesPeopleConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<ISpeciesPeopleEdge>;
+    totalCount: number;
+    people: Array<IPerson>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface ISpeciesPeopleEdge {
+    __typename: string;
+    node: IPerson;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface ISpeciesFilmsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<ISpeciesFilmsEdge>;
+    totalCount: number;
+    films: Array<IFilm>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface ISpeciesFilmsEdge {
+    __typename: string;
+    node: IFilm;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IPersonStarshipsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IPersonStarshipsEdge>;
+    totalCount: number;
+    starships: Array<IStarship>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IPersonStarshipsEdge {
+    __typename: string;
+    node: IStarship;
+    cursor: string;
+  }
+
+  /*
+    description: A single transport craft that has hyperdrive capability.
+  */
+  interface IStarship {
+    __typename: string;
+    name: string;
+    model: string;
+    starshipClass: string;
+    manufacturers: Array<string>;
+    costInCredits: number;
+    length: number;
+    crew: string;
+    passengers: string;
+    maxAtmospheringSpeed: number;
+    hyperdriveRating: number;
+    MGLT: number;
+    cargoCapacity: number;
+    consumables: string;
+    pilotConnection: IStarshipPilotsConnection;
+    filmConnection: IStarshipFilmsConnection;
+    created: string;
+    edited: string;
+    id: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IStarshipPilotsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IStarshipPilotsEdge>;
+    totalCount: number;
+    pilots: Array<IPerson>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IStarshipPilotsEdge {
+    __typename: string;
+    node: IPerson;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IStarshipFilmsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IStarshipFilmsEdge>;
+    totalCount: number;
+    films: Array<IFilm>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IStarshipFilmsEdge {
+    __typename: string;
+    node: IFilm;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IPersonVehiclesConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IPersonVehiclesEdge>;
+    totalCount: number;
+    vehicles: Array<IVehicle>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IPersonVehiclesEdge {
+    __typename: string;
+    node: IVehicle;
+    cursor: string;
+  }
+
+  /*
+    description: A single transport craft that does not have hyperdrive capability
+  */
+  interface IVehicle {
+    __typename: string;
+    name: string;
+    model: string;
+    vehicleClass: string;
+    manufacturers: Array<string>;
+    costInCredits: number;
+    length: number;
+    crew: string;
+    passengers: string;
+    maxAtmospheringSpeed: number;
+    cargoCapacity: number;
+    consumables: string;
+    pilotConnection: IVehiclePilotsConnection;
+    filmConnection: IVehicleFilmsConnection;
+    created: string;
+    edited: string;
+    id: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IVehiclePilotsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IVehiclePilotsEdge>;
+    totalCount: number;
+    pilots: Array<IPerson>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IVehiclePilotsEdge {
+    __typename: string;
+    node: IPerson;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IVehicleFilmsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IVehicleFilmsEdge>;
+    totalCount: number;
+    films: Array<IFilm>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IVehicleFilmsEdge {
+    __typename: string;
+    node: IFilm;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IPlanetFilmsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IPlanetFilmsEdge>;
+    totalCount: number;
+    films: Array<IFilm>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IPlanetFilmsEdge {
+    __typename: string;
+    node: IFilm;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IFilmSpeciesConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IFilmSpeciesEdge>;
+    totalCount: number;
+    species: Array<ISpecies>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IFilmSpeciesEdge {
+    __typename: string;
+    node: ISpecies;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IFilmStarshipsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IFilmStarshipsEdge>;
+    totalCount: number;
+    starships: Array<IStarship>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IFilmStarshipsEdge {
+    __typename: string;
+    node: IStarship;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IFilmVehiclesConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IFilmVehiclesEdge>;
+    totalCount: number;
+    vehicles: Array<IVehicle>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IFilmVehiclesEdge {
+    __typename: string;
+    node: IVehicle;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IFilmCharactersConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IFilmCharactersEdge>;
+    totalCount: number;
+    characters: Array<IPerson>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IFilmCharactersEdge {
+    __typename: string;
+    node: IPerson;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IFilmPlanetsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IFilmPlanetsEdge>;
+    totalCount: number;
+    planets: Array<IPlanet>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IFilmPlanetsEdge {
+    __typename: string;
+    node: IPlanet;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IPeopleConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IPeopleEdge>;
+    totalCount: number;
+    people: Array<IPerson>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IPeopleEdge {
+    __typename: string;
+    node: IPerson;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IPlanetsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IPlanetsEdge>;
+    totalCount: number;
+    planets: Array<IPlanet>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IPlanetsEdge {
+    __typename: string;
+    node: IPlanet;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface ISpeciesConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<ISpeciesEdge>;
+    totalCount: number;
+    species: Array<ISpecies>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface ISpeciesEdge {
+    __typename: string;
+    node: ISpecies;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IStarshipsConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IStarshipsEdge>;
+    totalCount: number;
+    starships: Array<IStarship>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IStarshipsEdge {
+    __typename: string;
+    node: IStarship;
+    cursor: string;
+  }
+
+  /*
+    description: A connection to a list of items.
+  */
+  interface IVehiclesConnection {
+    __typename: string;
+    pageInfo: IPageInfo;
+    edges: Array<IVehiclesEdge>;
+    totalCount: number;
+    vehicles: Array<IVehicle>;
+  }
+
+  /*
+    description: An edge in a connection.
+  */
+  interface IVehiclesEdge {
+    __typename: string;
+    node: IVehicle;
+    cursor: string;
+  }`

--- a/test/data/expectedNamespace.js
+++ b/test/data/expectedNamespace.js
@@ -22,19 +22,19 @@ declare namespace GQL {
   */
   interface IRoot {
     __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    person: IPerson;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
+    allFilms: IFilmsConnection | null;
+    film: IFilm | null;
+    allPeople: IPeopleConnection | null;
+    person: IPerson | null;
+    allPlanets: IPlanetsConnection | null;
+    planet: IPlanet | null;
+    allSpecies: ISpeciesConnection | null;
+    species: ISpecies | null;
+    allStarships: IStarshipsConnection | null;
+    starship: IStarship | null;
+    allVehicles: IVehiclesConnection | null;
+    vehicle: IVehicle | null;
+    node: Node | null;
   }
 
   /*
@@ -43,9 +43,9 @@ declare namespace GQL {
   interface IFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -55,8 +55,8 @@ declare namespace GQL {
     __typename: string;
     hasNextPage: boolean;
     hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
+    startCursor: string | null;
+    endCursor: string | null;
   }
 
   /*
@@ -64,7 +64,7 @@ declare namespace GQL {
   */
   interface IFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -73,19 +73,19 @@ declare namespace GQL {
   */
   interface IFilm {
     __typename: string;
-    title: string;
-    episodeID: number;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
+    title: string | null;
+    episodeID: number | null;
+    openingCrawl: string | null;
+    director: string | null;
+    producers: Array<string> | null;
+    releaseDate: string | null;
+    speciesConnection: IFilmSpeciesConnection | null;
+    starshipConnection: IFilmStarshipsConnection | null;
+    vehicleConnection: IFilmVehiclesConnection | null;
+    characterConnection: IFilmCharactersConnection | null;
+    planetConnection: IFilmPlanetsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -108,19 +108,19 @@ declare namespace GQL {
   */
   interface IPlanet {
     __typename: string;
-    name: string;
-    diameter: number;
-    rotationPeriod: number;
-    orbitalPeriod: number;
-    gravity: string;
-    population: number;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    diameter: number | null;
+    rotationPeriod: number | null;
+    orbitalPeriod: number | null;
+    gravity: string | null;
+    population: number | null;
+    climates: Array<string> | null;
+    terrains: Array<string> | null;
+    surfaceWater: number | null;
+    residentConnection: IPlanetResidentsConnection | null;
+    filmConnection: IPlanetFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -130,9 +130,9 @@ declare namespace GQL {
   interface IPlanetResidentsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: number;
-    residents: Array<IPerson>;
+    edges: Array<IPlanetResidentsEdge> | null;
+    totalCount: number | null;
+    residents: Array<IPerson> | null;
   }
 
   /*
@@ -140,7 +140,7 @@ declare namespace GQL {
   */
   interface IPlanetResidentsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -149,21 +149,21 @@ declare namespace GQL {
   */
   interface IPerson {
     __typename: string;
-    name: string;
-    birthYear: string;
-    eyeColor: string;
-    gender: string;
-    hairColor: string;
-    height: number;
-    mass: number;
-    skinColor: string;
-    homeworld: IPlanet;
-    filmConnection: IPersonFilmsConnection;
-    species: ISpecies;
-    starshipConnection: IPersonStarshipsConnection;
-    vehicleConnection: IPersonVehiclesConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    birthYear: string | null;
+    eyeColor: string | null;
+    gender: string | null;
+    hairColor: string | null;
+    height: number | null;
+    mass: number | null;
+    skinColor: string | null;
+    homeworld: IPlanet | null;
+    filmConnection: IPersonFilmsConnection | null;
+    species: ISpecies | null;
+    starshipConnection: IPersonStarshipsConnection | null;
+    vehicleConnection: IPersonVehiclesConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -173,9 +173,9 @@ declare namespace GQL {
   interface IPersonFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPersonFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -183,7 +183,7 @@ declare namespace GQL {
   */
   interface IPersonFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -192,20 +192,20 @@ declare namespace GQL {
   */
   interface ISpecies {
     __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: number;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    classification: string | null;
+    designation: string | null;
+    averageHeight: number | null;
+    averageLifespan: number | null;
+    eyeColors: Array<string> | null;
+    hairColors: Array<string> | null;
+    skinColors: Array<string> | null;
+    language: string | null;
+    homeworld: IPlanet | null;
+    personConnection: ISpeciesPeopleConnection | null;
+    filmConnection: ISpeciesFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -215,9 +215,9 @@ declare namespace GQL {
   interface ISpeciesPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: number;
-    people: Array<IPerson>;
+    edges: Array<ISpeciesPeopleEdge> | null;
+    totalCount: number | null;
+    people: Array<IPerson> | null;
   }
 
   /*
@@ -225,7 +225,7 @@ declare namespace GQL {
   */
   interface ISpeciesPeopleEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -235,9 +235,9 @@ declare namespace GQL {
   interface ISpeciesFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<ISpeciesFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -245,7 +245,7 @@ declare namespace GQL {
   */
   interface ISpeciesFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -255,9 +255,9 @@ declare namespace GQL {
   interface IPersonStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IPersonStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -265,7 +265,7 @@ declare namespace GQL {
   */
   interface IPersonStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -274,23 +274,23 @@ declare namespace GQL {
   */
   interface IStarship {
     __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    hyperdriveRating: number;
-    MGLT: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    starshipClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    hyperdriveRating: number | null;
+    MGLT: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IStarshipPilotsConnection | null;
+    filmConnection: IStarshipFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -300,9 +300,9 @@ declare namespace GQL {
   interface IStarshipPilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: number;
-    pilots: Array<IPerson>;
+    edges: Array<IStarshipPilotsEdge> | null;
+    totalCount: number | null;
+    pilots: Array<IPerson> | null;
   }
 
   /*
@@ -310,7 +310,7 @@ declare namespace GQL {
   */
   interface IStarshipPilotsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -320,9 +320,9 @@ declare namespace GQL {
   interface IStarshipFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IStarshipFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -330,7 +330,7 @@ declare namespace GQL {
   */
   interface IStarshipFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -340,9 +340,9 @@ declare namespace GQL {
   interface IPersonVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IPersonVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -350,7 +350,7 @@ declare namespace GQL {
   */
   interface IPersonVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -359,21 +359,21 @@ declare namespace GQL {
   */
   interface IVehicle {
     __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    vehicleClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IVehiclePilotsConnection | null;
+    filmConnection: IVehicleFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -383,9 +383,9 @@ declare namespace GQL {
   interface IVehiclePilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: number;
-    pilots: Array<IPerson>;
+    edges: Array<IVehiclePilotsEdge> | null;
+    totalCount: number | null;
+    pilots: Array<IPerson> | null;
   }
 
   /*
@@ -393,7 +393,7 @@ declare namespace GQL {
   */
   interface IVehiclePilotsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -403,9 +403,9 @@ declare namespace GQL {
   interface IVehicleFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IVehicleFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -413,7 +413,7 @@ declare namespace GQL {
   */
   interface IVehicleFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -423,9 +423,9 @@ declare namespace GQL {
   interface IPlanetFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPlanetFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -433,7 +433,7 @@ declare namespace GQL {
   */
   interface IPlanetFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -443,9 +443,9 @@ declare namespace GQL {
   interface IFilmSpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<IFilmSpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -453,7 +453,7 @@ declare namespace GQL {
   */
   interface IFilmSpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -463,9 +463,9 @@ declare namespace GQL {
   interface IFilmStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IFilmStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -473,7 +473,7 @@ declare namespace GQL {
   */
   interface IFilmStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -483,9 +483,9 @@ declare namespace GQL {
   interface IFilmVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IFilmVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -493,7 +493,7 @@ declare namespace GQL {
   */
   interface IFilmVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -503,9 +503,9 @@ declare namespace GQL {
   interface IFilmCharactersConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: number;
-    characters: Array<IPerson>;
+    edges: Array<IFilmCharactersEdge> | null;
+    totalCount: number | null;
+    characters: Array<IPerson> | null;
   }
 
   /*
@@ -513,7 +513,7 @@ declare namespace GQL {
   */
   interface IFilmCharactersEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -523,9 +523,9 @@ declare namespace GQL {
   interface IFilmPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IFilmPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -533,7 +533,7 @@ declare namespace GQL {
   */
   interface IFilmPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -543,9 +543,9 @@ declare namespace GQL {
   interface IPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: number;
-    people: Array<IPerson>;
+    edges: Array<IPeopleEdge> | null;
+    totalCount: number | null;
+    people: Array<IPerson> | null;
   }
 
   /*
@@ -553,7 +553,7 @@ declare namespace GQL {
   */
   interface IPeopleEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -563,9 +563,9 @@ declare namespace GQL {
   interface IPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -573,7 +573,7 @@ declare namespace GQL {
   */
   interface IPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -583,9 +583,9 @@ declare namespace GQL {
   interface ISpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<ISpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -593,7 +593,7 @@ declare namespace GQL {
   */
   interface ISpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -603,9 +603,9 @@ declare namespace GQL {
   interface IStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -613,7 +613,7 @@ declare namespace GQL {
   */
   interface IStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -623,9 +623,9 @@ declare namespace GQL {
   interface IVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -633,7 +633,7 @@ declare namespace GQL {
   */
   interface IVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 }

--- a/test/data/ignoredPerson.js
+++ b/test/data/ignoredPerson.js
@@ -22,18 +22,18 @@ declare namespace StarWars {
   */
   interface IRoot {
     __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
+    allFilms: IFilmsConnection | null;
+    film: IFilm | null;
+    allPeople: IPeopleConnection | null;
+    allPlanets: IPlanetsConnection | null;
+    planet: IPlanet | null;
+    allSpecies: ISpeciesConnection | null;
+    species: ISpecies | null;
+    allStarships: IStarshipsConnection | null;
+    starship: IStarship | null;
+    allVehicles: IVehiclesConnection | null;
+    vehicle: IVehicle | null;
+    node: Node | null;
   }
 
   /*
@@ -42,9 +42,9 @@ declare namespace StarWars {
   interface IFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -54,8 +54,8 @@ declare namespace StarWars {
     __typename: string;
     hasNextPage: boolean;
     hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
+    startCursor: string | null;
+    endCursor: string | null;
   }
 
   /*
@@ -63,7 +63,7 @@ declare namespace StarWars {
   */
   interface IFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -72,19 +72,19 @@ declare namespace StarWars {
   */
   interface IFilm {
     __typename: string;
-    title: string;
-    episodeID: number;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
+    title: string | null;
+    episodeID: number | null;
+    openingCrawl: string | null;
+    director: string | null;
+    producers: Array<string> | null;
+    releaseDate: string | null;
+    speciesConnection: IFilmSpeciesConnection | null;
+    starshipConnection: IFilmStarshipsConnection | null;
+    vehicleConnection: IFilmVehiclesConnection | null;
+    characterConnection: IFilmCharactersConnection | null;
+    planetConnection: IFilmPlanetsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -107,19 +107,19 @@ declare namespace StarWars {
   */
   interface IPlanet {
     __typename: string;
-    name: string;
-    diameter: number;
-    rotationPeriod: number;
-    orbitalPeriod: number;
-    gravity: string;
-    population: number;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    diameter: number | null;
+    rotationPeriod: number | null;
+    orbitalPeriod: number | null;
+    gravity: string | null;
+    population: number | null;
+    climates: Array<string> | null;
+    terrains: Array<string> | null;
+    surfaceWater: number | null;
+    residentConnection: IPlanetResidentsConnection | null;
+    filmConnection: IPlanetFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -129,8 +129,8 @@ declare namespace StarWars {
   interface IPlanetResidentsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: number;
+    edges: Array<IPlanetResidentsEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -147,9 +147,9 @@ declare namespace StarWars {
   interface IPersonFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPersonFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -157,7 +157,7 @@ declare namespace StarWars {
   */
   interface IPersonFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -166,20 +166,20 @@ declare namespace StarWars {
   */
   interface ISpecies {
     __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: number;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    classification: string | null;
+    designation: string | null;
+    averageHeight: number | null;
+    averageLifespan: number | null;
+    eyeColors: Array<string> | null;
+    hairColors: Array<string> | null;
+    skinColors: Array<string> | null;
+    language: string | null;
+    homeworld: IPlanet | null;
+    personConnection: ISpeciesPeopleConnection | null;
+    filmConnection: ISpeciesFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -189,8 +189,8 @@ declare namespace StarWars {
   interface ISpeciesPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: number;
+    edges: Array<ISpeciesPeopleEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -207,9 +207,9 @@ declare namespace StarWars {
   interface ISpeciesFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<ISpeciesFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -217,7 +217,7 @@ declare namespace StarWars {
   */
   interface ISpeciesFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -227,9 +227,9 @@ declare namespace StarWars {
   interface IPersonStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IPersonStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -237,7 +237,7 @@ declare namespace StarWars {
   */
   interface IPersonStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -246,23 +246,23 @@ declare namespace StarWars {
   */
   interface IStarship {
     __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    hyperdriveRating: number;
-    MGLT: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    starshipClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    hyperdriveRating: number | null;
+    MGLT: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IStarshipPilotsConnection | null;
+    filmConnection: IStarshipFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -272,8 +272,8 @@ declare namespace StarWars {
   interface IStarshipPilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: number;
+    edges: Array<IStarshipPilotsEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -290,9 +290,9 @@ declare namespace StarWars {
   interface IStarshipFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IStarshipFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -300,7 +300,7 @@ declare namespace StarWars {
   */
   interface IStarshipFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -310,9 +310,9 @@ declare namespace StarWars {
   interface IPersonVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IPersonVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -320,7 +320,7 @@ declare namespace StarWars {
   */
   interface IPersonVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -329,21 +329,21 @@ declare namespace StarWars {
   */
   interface IVehicle {
     __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    vehicleClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IVehiclePilotsConnection | null;
+    filmConnection: IVehicleFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -353,8 +353,8 @@ declare namespace StarWars {
   interface IVehiclePilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: number;
+    edges: Array<IVehiclePilotsEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -371,9 +371,9 @@ declare namespace StarWars {
   interface IVehicleFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IVehicleFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -381,7 +381,7 @@ declare namespace StarWars {
   */
   interface IVehicleFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -391,9 +391,9 @@ declare namespace StarWars {
   interface IPlanetFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPlanetFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -401,7 +401,7 @@ declare namespace StarWars {
   */
   interface IPlanetFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -411,9 +411,9 @@ declare namespace StarWars {
   interface IFilmSpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<IFilmSpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -421,7 +421,7 @@ declare namespace StarWars {
   */
   interface IFilmSpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -431,9 +431,9 @@ declare namespace StarWars {
   interface IFilmStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IFilmStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -441,7 +441,7 @@ declare namespace StarWars {
   */
   interface IFilmStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -451,9 +451,9 @@ declare namespace StarWars {
   interface IFilmVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IFilmVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -461,7 +461,7 @@ declare namespace StarWars {
   */
   interface IFilmVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -471,8 +471,8 @@ declare namespace StarWars {
   interface IFilmCharactersConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: number;
+    edges: Array<IFilmCharactersEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -489,9 +489,9 @@ declare namespace StarWars {
   interface IFilmPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IFilmPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -499,7 +499,7 @@ declare namespace StarWars {
   */
   interface IFilmPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -509,8 +509,8 @@ declare namespace StarWars {
   interface IPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: number;
+    edges: Array<IPeopleEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -527,9 +527,9 @@ declare namespace StarWars {
   interface IPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -537,7 +537,7 @@ declare namespace StarWars {
   */
   interface IPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -547,9 +547,9 @@ declare namespace StarWars {
   interface ISpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<ISpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -557,7 +557,7 @@ declare namespace StarWars {
   */
   interface ISpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -567,9 +567,9 @@ declare namespace StarWars {
   interface IStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -577,7 +577,7 @@ declare namespace StarWars {
   */
   interface IStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -587,9 +587,9 @@ declare namespace StarWars {
   interface IVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -597,7 +597,7 @@ declare namespace StarWars {
   */
   interface IVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 }

--- a/test/data/ignoredPersonInterfaces.js
+++ b/test/data/ignoredPersonInterfaces.js
@@ -19,18 +19,18 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IRoot {
     __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
+    allFilms: IFilmsConnection | null;
+    film: IFilm | null;
+    allPeople: IPeopleConnection | null;
+    allPlanets: IPlanetsConnection | null;
+    planet: IPlanet | null;
+    allSpecies: ISpeciesConnection | null;
+    species: ISpecies | null;
+    allStarships: IStarshipsConnection | null;
+    starship: IStarship | null;
+    allVehicles: IVehiclesConnection | null;
+    vehicle: IVehicle | null;
+    node: Node | null;
   }
 
   /*
@@ -39,9 +39,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -51,8 +51,8 @@ module.exports = `  interface IGraphQLResponseRoot {
     __typename: string;
     hasNextPage: boolean;
     hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
+    startCursor: string | null;
+    endCursor: string | null;
   }
 
   /*
@@ -60,7 +60,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -69,19 +69,19 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilm {
     __typename: string;
-    title: string;
-    episodeID: number;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
+    title: string | null;
+    episodeID: number | null;
+    openingCrawl: string | null;
+    director: string | null;
+    producers: Array<string> | null;
+    releaseDate: string | null;
+    speciesConnection: IFilmSpeciesConnection | null;
+    starshipConnection: IFilmStarshipsConnection | null;
+    vehicleConnection: IFilmVehiclesConnection | null;
+    characterConnection: IFilmCharactersConnection | null;
+    planetConnection: IFilmPlanetsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -104,19 +104,19 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPlanet {
     __typename: string;
-    name: string;
-    diameter: number;
-    rotationPeriod: number;
-    orbitalPeriod: number;
-    gravity: string;
-    population: number;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    diameter: number | null;
+    rotationPeriod: number | null;
+    orbitalPeriod: number | null;
+    gravity: string | null;
+    population: number | null;
+    climates: Array<string> | null;
+    terrains: Array<string> | null;
+    surfaceWater: number | null;
+    residentConnection: IPlanetResidentsConnection | null;
+    filmConnection: IPlanetFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -126,8 +126,8 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPlanetResidentsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: number;
+    edges: Array<IPlanetResidentsEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -144,9 +144,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPersonFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPersonFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -154,7 +154,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPersonFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -163,20 +163,20 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface ISpecies {
     __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: number;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    classification: string | null;
+    designation: string | null;
+    averageHeight: number | null;
+    averageLifespan: number | null;
+    eyeColors: Array<string> | null;
+    hairColors: Array<string> | null;
+    skinColors: Array<string> | null;
+    language: string | null;
+    homeworld: IPlanet | null;
+    personConnection: ISpeciesPeopleConnection | null;
+    filmConnection: ISpeciesFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -186,8 +186,8 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface ISpeciesPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: number;
+    edges: Array<ISpeciesPeopleEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -204,9 +204,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface ISpeciesFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<ISpeciesFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -214,7 +214,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface ISpeciesFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -224,9 +224,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPersonStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IPersonStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -234,7 +234,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPersonStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -243,23 +243,23 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IStarship {
     __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    hyperdriveRating: number;
-    MGLT: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    starshipClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    hyperdriveRating: number | null;
+    MGLT: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IStarshipPilotsConnection | null;
+    filmConnection: IStarshipFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -269,8 +269,8 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IStarshipPilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: number;
+    edges: Array<IStarshipPilotsEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -287,9 +287,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IStarshipFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IStarshipFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -297,7 +297,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IStarshipFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -307,9 +307,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPersonVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IPersonVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -317,7 +317,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPersonVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -326,21 +326,21 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IVehicle {
     __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    vehicleClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IVehiclePilotsConnection | null;
+    filmConnection: IVehicleFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -350,8 +350,8 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IVehiclePilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: number;
+    edges: Array<IVehiclePilotsEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -368,9 +368,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IVehicleFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IVehicleFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -378,7 +378,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IVehicleFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -388,9 +388,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPlanetFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPlanetFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -398,7 +398,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPlanetFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -408,9 +408,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmSpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<IFilmSpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -418,7 +418,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmSpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -428,9 +428,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IFilmStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -438,7 +438,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -448,9 +448,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IFilmVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -458,7 +458,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -468,8 +468,8 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmCharactersConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: number;
+    edges: Array<IFilmCharactersEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -486,9 +486,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IFilmPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IFilmPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -496,7 +496,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IFilmPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -506,8 +506,8 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: number;
+    edges: Array<IPeopleEdge> | null;
+    totalCount: number | null;
   }
 
   /*
@@ -524,9 +524,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -534,7 +534,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -544,9 +544,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface ISpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<ISpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -554,7 +554,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface ISpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -564,9 +564,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -574,7 +574,7 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -584,9 +584,9 @@ module.exports = `  interface IGraphQLResponseRoot {
   interface IVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -594,6 +594,6 @@ module.exports = `  interface IGraphQLResponseRoot {
   */
   interface IVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }`

--- a/test/data/starWarsNamespace.js
+++ b/test/data/starWarsNamespace.js
@@ -22,19 +22,19 @@ declare namespace StarWars {
   */
   interface IRoot {
     __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    person: IPerson;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
+    allFilms: IFilmsConnection | null;
+    film: IFilm | null;
+    allPeople: IPeopleConnection | null;
+    person: IPerson | null;
+    allPlanets: IPlanetsConnection | null;
+    planet: IPlanet | null;
+    allSpecies: ISpeciesConnection | null;
+    species: ISpecies | null;
+    allStarships: IStarshipsConnection | null;
+    starship: IStarship | null;
+    allVehicles: IVehiclesConnection | null;
+    vehicle: IVehicle | null;
+    node: Node | null;
   }
 
   /*
@@ -43,9 +43,9 @@ declare namespace StarWars {
   interface IFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -55,8 +55,8 @@ declare namespace StarWars {
     __typename: string;
     hasNextPage: boolean;
     hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
+    startCursor: string | null;
+    endCursor: string | null;
   }
 
   /*
@@ -64,7 +64,7 @@ declare namespace StarWars {
   */
   interface IFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -73,19 +73,19 @@ declare namespace StarWars {
   */
   interface IFilm {
     __typename: string;
-    title: string;
-    episodeID: number;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
+    title: string | null;
+    episodeID: number | null;
+    openingCrawl: string | null;
+    director: string | null;
+    producers: Array<string> | null;
+    releaseDate: string | null;
+    speciesConnection: IFilmSpeciesConnection | null;
+    starshipConnection: IFilmStarshipsConnection | null;
+    vehicleConnection: IFilmVehiclesConnection | null;
+    characterConnection: IFilmCharactersConnection | null;
+    planetConnection: IFilmPlanetsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -108,19 +108,19 @@ declare namespace StarWars {
   */
   interface IPlanet {
     __typename: string;
-    name: string;
-    diameter: number;
-    rotationPeriod: number;
-    orbitalPeriod: number;
-    gravity: string;
-    population: number;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    diameter: number | null;
+    rotationPeriod: number | null;
+    orbitalPeriod: number | null;
+    gravity: string | null;
+    population: number | null;
+    climates: Array<string> | null;
+    terrains: Array<string> | null;
+    surfaceWater: number | null;
+    residentConnection: IPlanetResidentsConnection | null;
+    filmConnection: IPlanetFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -130,9 +130,9 @@ declare namespace StarWars {
   interface IPlanetResidentsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: number;
-    residents: Array<IPerson>;
+    edges: Array<IPlanetResidentsEdge> | null;
+    totalCount: number | null;
+    residents: Array<IPerson> | null;
   }
 
   /*
@@ -140,7 +140,7 @@ declare namespace StarWars {
   */
   interface IPlanetResidentsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -149,21 +149,21 @@ declare namespace StarWars {
   */
   interface IPerson {
     __typename: string;
-    name: string;
-    birthYear: string;
-    eyeColor: string;
-    gender: string;
-    hairColor: string;
-    height: number;
-    mass: number;
-    skinColor: string;
-    homeworld: IPlanet;
-    filmConnection: IPersonFilmsConnection;
-    species: ISpecies;
-    starshipConnection: IPersonStarshipsConnection;
-    vehicleConnection: IPersonVehiclesConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    birthYear: string | null;
+    eyeColor: string | null;
+    gender: string | null;
+    hairColor: string | null;
+    height: number | null;
+    mass: number | null;
+    skinColor: string | null;
+    homeworld: IPlanet | null;
+    filmConnection: IPersonFilmsConnection | null;
+    species: ISpecies | null;
+    starshipConnection: IPersonStarshipsConnection | null;
+    vehicleConnection: IPersonVehiclesConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -173,9 +173,9 @@ declare namespace StarWars {
   interface IPersonFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPersonFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -183,7 +183,7 @@ declare namespace StarWars {
   */
   interface IPersonFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -192,20 +192,20 @@ declare namespace StarWars {
   */
   interface ISpecies {
     __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: number;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    classification: string | null;
+    designation: string | null;
+    averageHeight: number | null;
+    averageLifespan: number | null;
+    eyeColors: Array<string> | null;
+    hairColors: Array<string> | null;
+    skinColors: Array<string> | null;
+    language: string | null;
+    homeworld: IPlanet | null;
+    personConnection: ISpeciesPeopleConnection | null;
+    filmConnection: ISpeciesFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -215,9 +215,9 @@ declare namespace StarWars {
   interface ISpeciesPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: number;
-    people: Array<IPerson>;
+    edges: Array<ISpeciesPeopleEdge> | null;
+    totalCount: number | null;
+    people: Array<IPerson> | null;
   }
 
   /*
@@ -225,7 +225,7 @@ declare namespace StarWars {
   */
   interface ISpeciesPeopleEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -235,9 +235,9 @@ declare namespace StarWars {
   interface ISpeciesFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<ISpeciesFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -245,7 +245,7 @@ declare namespace StarWars {
   */
   interface ISpeciesFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -255,9 +255,9 @@ declare namespace StarWars {
   interface IPersonStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IPersonStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -265,7 +265,7 @@ declare namespace StarWars {
   */
   interface IPersonStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -274,23 +274,23 @@ declare namespace StarWars {
   */
   interface IStarship {
     __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    hyperdriveRating: number;
-    MGLT: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    starshipClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    hyperdriveRating: number | null;
+    MGLT: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IStarshipPilotsConnection | null;
+    filmConnection: IStarshipFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -300,9 +300,9 @@ declare namespace StarWars {
   interface IStarshipPilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: number;
-    pilots: Array<IPerson>;
+    edges: Array<IStarshipPilotsEdge> | null;
+    totalCount: number | null;
+    pilots: Array<IPerson> | null;
   }
 
   /*
@@ -310,7 +310,7 @@ declare namespace StarWars {
   */
   interface IStarshipPilotsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -320,9 +320,9 @@ declare namespace StarWars {
   interface IStarshipFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IStarshipFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -330,7 +330,7 @@ declare namespace StarWars {
   */
   interface IStarshipFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -340,9 +340,9 @@ declare namespace StarWars {
   interface IPersonVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IPersonVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -350,7 +350,7 @@ declare namespace StarWars {
   */
   interface IPersonVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -359,21 +359,21 @@ declare namespace StarWars {
   */
   interface IVehicle {
     __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: number;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
+    name: string | null;
+    model: string | null;
+    vehicleClass: string | null;
+    manufacturers: Array<string> | null;
+    costInCredits: number | null;
+    length: number | null;
+    crew: string | null;
+    passengers: string | null;
+    maxAtmospheringSpeed: number | null;
+    cargoCapacity: number | null;
+    consumables: string | null;
+    pilotConnection: IVehiclePilotsConnection | null;
+    filmConnection: IVehicleFilmsConnection | null;
+    created: string | null;
+    edited: string | null;
     id: string;
   }
 
@@ -383,9 +383,9 @@ declare namespace StarWars {
   interface IVehiclePilotsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: number;
-    pilots: Array<IPerson>;
+    edges: Array<IVehiclePilotsEdge> | null;
+    totalCount: number | null;
+    pilots: Array<IPerson> | null;
   }
 
   /*
@@ -393,7 +393,7 @@ declare namespace StarWars {
   */
   interface IVehiclePilotsEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -403,9 +403,9 @@ declare namespace StarWars {
   interface IVehicleFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IVehicleFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -413,7 +413,7 @@ declare namespace StarWars {
   */
   interface IVehicleFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -423,9 +423,9 @@ declare namespace StarWars {
   interface IPlanetFilmsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: number;
-    films: Array<IFilm>;
+    edges: Array<IPlanetFilmsEdge> | null;
+    totalCount: number | null;
+    films: Array<IFilm> | null;
   }
 
   /*
@@ -433,7 +433,7 @@ declare namespace StarWars {
   */
   interface IPlanetFilmsEdge {
     __typename: string;
-    node: IFilm;
+    node: IFilm | null;
     cursor: string;
   }
 
@@ -443,9 +443,9 @@ declare namespace StarWars {
   interface IFilmSpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<IFilmSpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -453,7 +453,7 @@ declare namespace StarWars {
   */
   interface IFilmSpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -463,9 +463,9 @@ declare namespace StarWars {
   interface IFilmStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IFilmStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -473,7 +473,7 @@ declare namespace StarWars {
   */
   interface IFilmStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -483,9 +483,9 @@ declare namespace StarWars {
   interface IFilmVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IFilmVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -493,7 +493,7 @@ declare namespace StarWars {
   */
   interface IFilmVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 
@@ -503,9 +503,9 @@ declare namespace StarWars {
   interface IFilmCharactersConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: number;
-    characters: Array<IPerson>;
+    edges: Array<IFilmCharactersEdge> | null;
+    totalCount: number | null;
+    characters: Array<IPerson> | null;
   }
 
   /*
@@ -513,7 +513,7 @@ declare namespace StarWars {
   */
   interface IFilmCharactersEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -523,9 +523,9 @@ declare namespace StarWars {
   interface IFilmPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IFilmPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -533,7 +533,7 @@ declare namespace StarWars {
   */
   interface IFilmPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -543,9 +543,9 @@ declare namespace StarWars {
   interface IPeopleConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: number;
-    people: Array<IPerson>;
+    edges: Array<IPeopleEdge> | null;
+    totalCount: number | null;
+    people: Array<IPerson> | null;
   }
 
   /*
@@ -553,7 +553,7 @@ declare namespace StarWars {
   */
   interface IPeopleEdge {
     __typename: string;
-    node: IPerson;
+    node: IPerson | null;
     cursor: string;
   }
 
@@ -563,9 +563,9 @@ declare namespace StarWars {
   interface IPlanetsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: number;
-    planets: Array<IPlanet>;
+    edges: Array<IPlanetsEdge> | null;
+    totalCount: number | null;
+    planets: Array<IPlanet> | null;
   }
 
   /*
@@ -573,7 +573,7 @@ declare namespace StarWars {
   */
   interface IPlanetsEdge {
     __typename: string;
-    node: IPlanet;
+    node: IPlanet | null;
     cursor: string;
   }
 
@@ -583,9 +583,9 @@ declare namespace StarWars {
   interface ISpeciesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: number;
-    species: Array<ISpecies>;
+    edges: Array<ISpeciesEdge> | null;
+    totalCount: number | null;
+    species: Array<ISpecies> | null;
   }
 
   /*
@@ -593,7 +593,7 @@ declare namespace StarWars {
   */
   interface ISpeciesEdge {
     __typename: string;
-    node: ISpecies;
+    node: ISpecies | null;
     cursor: string;
   }
 
@@ -603,9 +603,9 @@ declare namespace StarWars {
   interface IStarshipsConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: number;
-    starships: Array<IStarship>;
+    edges: Array<IStarshipsEdge> | null;
+    totalCount: number | null;
+    starships: Array<IStarship> | null;
   }
 
   /*
@@ -613,7 +613,7 @@ declare namespace StarWars {
   */
   interface IStarshipsEdge {
     __typename: string;
-    node: IStarship;
+    node: IStarship | null;
     cursor: string;
   }
 
@@ -623,9 +623,9 @@ declare namespace StarWars {
   interface IVehiclesConnection {
     __typename: string;
     pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: number;
-    vehicles: Array<IVehicle>;
+    edges: Array<IVehiclesEdge> | null;
+    totalCount: number | null;
+    vehicles: Array<IVehicle> | null;
   }
 
   /*
@@ -633,7 +633,7 @@ declare namespace StarWars {
   */
   interface IVehiclesEdge {
     __typename: string;
-    node: IVehicle;
+    node: IVehicle | null;
     cursor: string;
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ let schema         = require('./data/starWarsSchema');
 let enumSchema     = require('./data/enumSchema');
 let expectedNamespace  = require('./data/expectedNamespace');
 let expectedInterfaces = require('./data/expectedInterfaces');
+let expectedLegacyInterfaces = require('./data/expectedLegacyInterfaces');
 
 describe('gql2ts', () => {
   describe('interfaces', () => {
@@ -61,6 +62,13 @@ describe('gql2ts', () => {
       let enumNamespace = require('./data/expectedEnum');
 
       expect(namespace).to.equal(enumNamespace);
+    });
+  });
+
+  describe('Supports older TypeScript versions', () => {
+    it('removes Nullability annotations when passed', () => {
+      let interfaces = interfaceUtils.schemaToInterfaces(schema, { ignoredTypes: [], legacy: true });
+      expect(interfaces).to.equal(expectedLegacyInterfaces);
     });
   });
 });

--- a/util/interface.js
+++ b/util/interface.js
@@ -112,10 +112,10 @@ const fieldToDefinition = (field, isInput) => {
     interfaceName = interfaceName.replace(/\!/g, '');
   }
 
-  if (isInput && !isNotNull) {
-    fieldDef = `${field.name}?: ${interfaceName}`;
+  if (isInput) {
+    fieldDef = `${field.name}${isNotNull ? '' : '?'}: ${interfaceName}`;
   } else {
-    fieldDef = `${field.name}: ${interfaceName}`;
+    fieldDef = `${field.name}: ${interfaceName}${isNotNull ? '' : ' | null'}`;
   }
 
   return `    ${fieldDef};`;


### PR DESCRIPTION
Given that TypeScript 2.x is now in production and pretty stable, I opted for a `--legacy` CLI argument to #32 - I've imported the old interface test JS as a test case for the older output format.

Fixes #18 #32 