### PR TITLE
Disable tslint in generated file

### DIFF
--- a/test/data/expectedEnum.js
+++ b/test/data/expectedEnum.js
@@ -1,4 +1,5 @@
 module.exports = `// graphql typescript definitions
+/* tslint:disable */
 
 declare namespace GQL {
   interface IGraphQLResponseRoot {
@@ -30,4 +31,5 @@ declare namespace GQL {
   */
   type IColorEnum = "RED" | "GREEN" | "BLUE";
 }
+/* tslint:enable */
 `

--- a/test/data/expectedEnum.js
+++ b/test/data/expectedEnum.js
@@ -1,5 +1,5 @@
-module.exports = `// graphql typescript definitions
-/* tslint:disable */
+module.exports = `// tslint:disable
+// graphql typescript definitions
 
 declare namespace GQL {
   interface IGraphQLResponseRoot {
@@ -31,6 +31,6 @@ declare namespace GQL {
   */
   type IColorEnum = "RED" | "GREEN" | "BLUE";
 }
-/* tslint:enable */
 
+// tslint:enable
 `

--- a/test/data/expectedEnum.js
+++ b/test/data/expectedEnum.js
@@ -32,4 +32,5 @@ declare namespace GQL {
   type IColorEnum = "RED" | "GREEN" | "BLUE";
 }
 /* tslint:enable */
+
 `

--- a/test/data/expectedNamespace.js
+++ b/test/data/expectedNamespace.js
@@ -1,4 +1,5 @@
 module.exports = `// graphql typescript definitions
+/* tslint:disable */
 
 declare namespace GQL {
   interface IGraphQLResponseRoot {
@@ -637,4 +638,5 @@ declare namespace GQL {
     cursor: string;
   }
 }
+/* tslint:enable */
 `

--- a/test/data/expectedNamespace.js
+++ b/test/data/expectedNamespace.js
@@ -639,4 +639,5 @@ declare namespace GQL {
   }
 }
 /* tslint:enable */
+
 `

--- a/test/data/expectedNamespace.js
+++ b/test/data/expectedNamespace.js
@@ -1,5 +1,5 @@
-module.exports = `// graphql typescript definitions
-/* tslint:disable */
+module.exports = `// tslint:disable
+// graphql typescript definitions
 
 declare namespace GQL {
   interface IGraphQLResponseRoot {
@@ -638,6 +638,6 @@ declare namespace GQL {
     cursor: string;
   }
 }
-/* tslint:enable */
 
+// tslint:enable
 `

--- a/test/data/ignoredPerson.js
+++ b/test/data/ignoredPerson.js
@@ -1,5 +1,5 @@
-module.exports = `// graphql typescript definitions
-/* tslint:disable */
+module.exports = `// tslint:disable
+// graphql typescript definitions
 
 declare namespace StarWars {
   interface IGraphQLResponseRoot {
@@ -602,6 +602,6 @@ declare namespace StarWars {
     cursor: string;
   }
 }
-/* tslint:enable */
 
+// tslint:enable
 `

--- a/test/data/ignoredPerson.js
+++ b/test/data/ignoredPerson.js
@@ -1,4 +1,5 @@
 module.exports = `// graphql typescript definitions
+/* tslint:disable */
 
 declare namespace StarWars {
   interface IGraphQLResponseRoot {
@@ -601,4 +602,5 @@ declare namespace StarWars {
     cursor: string;
   }
 }
+/* tslint:enable */
 `

--- a/test/data/ignoredPerson.js
+++ b/test/data/ignoredPerson.js
@@ -603,4 +603,5 @@ declare namespace StarWars {
   }
 }
 /* tslint:enable */
+
 `

--- a/test/data/starWarsNamespace.js
+++ b/test/data/starWarsNamespace.js
@@ -1,4 +1,5 @@
 module.exports = `// graphql typescript definitions
+/* tslint:disable */
 
 declare namespace StarWars {
   interface IGraphQLResponseRoot {
@@ -637,4 +638,5 @@ declare namespace StarWars {
     cursor: string;
   }
 }
+/* tslint:enable */
 `

--- a/test/data/starWarsNamespace.js
+++ b/test/data/starWarsNamespace.js
@@ -1,5 +1,5 @@
-module.exports = `// graphql typescript definitions
-/* tslint:disable */
+module.exports = `// tslint:disable
+// graphql typescript definitions
 
 declare namespace StarWars {
   interface IGraphQLResponseRoot {
@@ -638,6 +638,6 @@ declare namespace StarWars {
     cursor: string;
   }
 }
-/* tslint:enable */
 
+// tslint:enable
 `

--- a/test/data/starWarsNamespace.js
+++ b/test/data/starWarsNamespace.js
@@ -639,4 +639,5 @@ declare namespace StarWars {
   }
 }
 /* tslint:enable */
+
 `

--- a/util/namespace.js
+++ b/util/namespace.js
@@ -9,6 +9,7 @@ declare namespace ${namespaceName} {
 ${interfaces}
 }
 /* tslint:enable */
+
 `;
 
 const writeNamespaceToFile = (outputFile, namespace) => fileIO.writeToFile(outputFile, namespace);

--- a/util/namespace.js
+++ b/util/namespace.js
@@ -3,10 +3,12 @@
 const fileIO = require('./fileIO');
 
 const generateNamespace = (namespaceName, interfaces) => `// graphql typescript definitions
+/* tslint:disable */
 
 declare namespace ${namespaceName} {
 ${interfaces}
 }
+/* tslint:enable */
 `;
 
 const writeNamespaceToFile = (outputFile, namespace) => fileIO.writeToFile(outputFile, namespace);

--- a/util/namespace.js
+++ b/util/namespace.js
@@ -2,14 +2,14 @@
 'use strict';
 const fileIO = require('./fileIO');
 
-const generateNamespace = (namespaceName, interfaces) => `// graphql typescript definitions
-/* tslint:disable */
+const generateNamespace = (namespaceName, interfaces) => `// tslint:disable
+// graphql typescript definitions
 
 declare namespace ${namespaceName} {
 ${interfaces}
 }
-/* tslint:enable */
 
+// tslint:enable
 `;
 
 const writeNamespaceToFile = (outputFile, namespace) => fileIO.writeToFile(outputFile, namespace);


### PR DESCRIPTION
Excluding files in TSLint via `tslint.json` is not supported and when using this tool TSLint may fail because of incompatibility.
Auto-generated code shouldn't pass thru TSLint so this change adds `tslint-disable` statement to the generated file and makes it safe to use with any TSLint configuration.