### PR TITLE
Make externalOptions value available to cli

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,7 @@ program
   .option('-n --namespace [namespace]', 'name for the namespace, defaults to "GQL"', 'GQL')
   .option('-i --ignored-types <ignoredTypes>', 'names of types to ignore (comma delimited)', v => v.split(','), [])
   .option('-l --legacy', 'Use TypeScript 1.x annotation', false)
-  .option('-e --external-options', 'ES Module with method overwrites')
+  .option('-e --external-options [externalOptions]', 'ES Module with method overwrites')
   .parse(process.argv);
 
 interface ICLIOptions extends Partial<ISchemaToInterfaceOptions> {


### PR DESCRIPTION
Otherwise just the boolean `true` gets passed to `require`

Addresses issue identified in https://github.com/avantcredit/gql2ts/issues/51