### PR TITLE
IgnoreTypeNameDeclaration option

### DIFF
--- a/packages/from-schema/src/index.ts
+++ b/packages/from-schema/src/index.ts
@@ -93,7 +93,9 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
 
   const generateInterfaceDeclaration: GenerateInterfaceDeclaration =
     (description, declaration, fields, additionalInfo, isInput) => {
-      if (!isInput) { fields = [typeNameDeclaration, ...fields]; }
+      if (!isInput) {
+        fields = [optionsInput.ignoreTypeNameDeclaration ? '' : typeNameDeclaration, ...fields];
+      }
       return additionalInfo + wrapWithDescription(interfaceBuilder(declaration, gID(fields.map(f => `    ${f}`), '  ')), description);
     };
 
@@ -280,6 +282,7 @@ export const generateNamespace: GenerateNamespace = (namespace, schema, options,
 export interface ISchemaToInterfaceOptions {
   legacy?: boolean;
   ignoredTypes: string[];
+  ignoreTypeNameDeclaration?: boolean;
   namespace: string;
   outputFile?: string;
   externalOptions?: string;

--- a/packages/from-schema/src/index.ts
+++ b/packages/from-schema/src/index.ts
@@ -93,8 +93,8 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
 
   const generateInterfaceDeclaration: GenerateInterfaceDeclaration =
     (description, declaration, fields, additionalInfo, isInput) => {
-      if (!isInput) {
-        fields = [optionsInput.ignoreTypeNameDeclaration ? '' : typeNameDeclaration, ...fields];
+      if (!isInput && !optionsInput.ignoreTypeNameDeclaration) {
+       fields =  [typeNameDeclaration, ...fields];
       }
       return additionalInfo + wrapWithDescription(interfaceBuilder(declaration, gID(fields.map(f => `    ${f}`), '  ')), description);
     };


### PR DESCRIPTION
Hi,
First off, thanks for this helpful lib.

While using it I realized I didn't need the extra ``__typename `` field added to interfaces when using the generateNamespace function.

To get rid of It I added an optional, option to Ignore adding the typename field with logic that defaults to adding it.

Let me know if this is useful.
