### PR TITLE
Modify the CLI to check for schema file first followed by stdin.

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,7 +62,10 @@ const run: (schema: PossibleSchemaInput, options: Partial<ICLIOptions>) => void 
 
 const fileName: string | undefined = program.args[0];
 
-if (!process.stdin.isTTY) {
+if (fileName) {
+  const schema: string | object = readFile(fileName);
+  run(schema as PossibleSchemaInput, program as any);
+} else if (!process.stdin.isTTY) {
   let input: string = '';
   process.stdin.resume();
   process.stdin.setEncoding('utf8');
@@ -70,9 +73,6 @@ if (!process.stdin.isTTY) {
     input += data;
   });
   process.stdin.on('end', () => run(safeJSONParse(input) as PossibleSchemaInput, program as any));
-} else if (fileName) {
-  const schema: string | object = readFile(fileName);
-  run(schema as PossibleSchemaInput, program as any);
 } else {
   console.error('No input specified. Please use stdin or a file name.');
   program.outputHelp();


### PR DESCRIPTION
process.stdin.isTTY is always false during Bazel build execution, so the schema file name is ignored and an error is thrown.
See: https://docs.bazel.build/versions/master/user-manual.html#flag--run_under