### PR TITLE
remove formatter for typescript

### DIFF
--- a/__tests__/__snapshots__/from-query-mutations-test.ts.snap
+++ b/__tests__/__snapshots__/from-query-mutations-test.ts.snap
@@ -8,21 +8,25 @@ Array [
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "result": "export interface CreateMessageInput {
   author?: string | null;
   content?: string | null;
 }
 
+
 export interface CreateMessage {
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "variables": "export interface CreateMessageInput {
   author?: string | null;
   content?: string | null;
-}",
+}
+",
   },
 ]
 `;
@@ -35,12 +39,14 @@ Array [
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "result": "export interface CreateMessage {
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -54,7 +60,8 @@ Array [
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "result": "export interface CreateMessageInput {
   input: {
     content?: string | null;
@@ -62,17 +69,20 @@ Array [
   };
 }
 
+
 export interface CreateMessage {
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "variables": "export interface CreateMessageInput {
   input: {
     content?: string | null;
     author?: string | null;
   };
-}",
+}
+",
   },
 ]
 `;
@@ -85,7 +95,8 @@ Array [
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "result": "export interface CreateMessageInput {
   input?: {
     content?: string | null;
@@ -93,17 +104,20 @@ Array [
   } | null;
 }
 
+
 export interface CreateMessage {
   createMessage: {
     id: string;
   } | null;
-}",
+}
+",
     "variables": "export interface CreateMessageInput {
   input?: {
     content?: string | null;
     author?: string | null;
   } | null;
-}",
+}
+",
   },
 ]
 `;

--- a/__tests__/__snapshots__/from-query-normalSchema-test.ts.snap
+++ b/__tests__/__snapshots__/from-query-normalSchema-test.ts.snap
@@ -9,13 +9,15 @@ Array [
     id: string;
     name: string | null;
   }> | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: Partial<{
     id: string;
     name: string | null;
   }> | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -30,13 +32,15 @@ Array [
     b: string;
     c: string | null;
   }> | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   a: Partial<{
     b: string;
     c: string | null;
   }> | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -48,20 +52,24 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   a: Partial<IFragmentCharacterFields> | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   a: Partial<IFragmentCharacterFields> | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   b: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   b: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -73,20 +81,24 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: Partial<IFragmentCharacterFields> | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: Partial<IFragmentCharacterFields> | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -101,13 +113,15 @@ Array [
     primaryFunction?: string | null;
     primaryFunctionNonNull?: string;
   }> | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: Partial<{
     primaryFunction?: string | null;
     primaryFunctionNonNull?: string;
   }> | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -122,13 +136,15 @@ Array [
     b?: string | null;
     c?: string;
   }> | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   a: Partial<{
     b?: string | null;
     c?: string;
   }> | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -143,13 +159,15 @@ Array [
     id?: string;
     name?: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface TestQuery {
   heroNoParam: {
     id?: string;
     name?: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -164,13 +182,15 @@ Array [
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface TestQuery {
   heroNoParam: {
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -185,13 +205,15 @@ Array [
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: {
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -206,13 +228,15 @@ Array [
     b: string;
     c: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   a: {
     b: string;
     c: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -227,13 +251,15 @@ Array [
     primaryFunction?: string | null;
     primaryFunctionNonNull?: string;
   } | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: {
     primaryFunction?: string | null;
     primaryFunctionNonNull?: string;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -248,13 +274,15 @@ Array [
     b?: string | null;
     c?: string;
   } | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   a: {
     b?: string | null;
     c?: string;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -266,30 +294,36 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   friends: Array<IFragmentCharacterFieldsNested | null> | null;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   friends: Array<IFragmentCharacterFieldsNested | null> | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFieldsNested {
   id: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFieldsNested {
   id: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -301,30 +335,38 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
-    "interface": "export interface IFragmentCharacterFields extends IFragmentCharacterFieldsNested {
+    "interface": "export interface IFragmentCharacterFields
+  extends IFragmentCharacterFieldsNested {
   friends: Array<IFragmentCharacterFieldsNested | null> | null;
-}",
-    "result": "export interface IFragmentCharacterFields extends IFragmentCharacterFieldsNested {
+}
+",
+    "result": "export interface IFragmentCharacterFields
+  extends IFragmentCharacterFieldsNested {
   friends: Array<IFragmentCharacterFieldsNested | null> | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFieldsNested {
   id: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFieldsNested {
   id: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -336,40 +378,52 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
-    "interface": "export interface IFragmentCharacterFields extends IFragmentCharacterFieldsNested, IFragmentCharacterFieldsNestedAgain {
+    "interface": "export interface IFragmentCharacterFields
+  extends IFragmentCharacterFieldsNested,
+    IFragmentCharacterFieldsNestedAgain {
   friends: Array<IFragmentCharacterFieldsNested | null> | null;
-}",
-    "result": "export interface IFragmentCharacterFields extends IFragmentCharacterFieldsNested, IFragmentCharacterFieldsNestedAgain {
+}
+",
+    "result": "export interface IFragmentCharacterFields
+  extends IFragmentCharacterFieldsNested,
+    IFragmentCharacterFieldsNestedAgain {
   friends: Array<IFragmentCharacterFieldsNested | null> | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFieldsNested {
   id: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFieldsNested {
   id: string;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFieldsNestedAgain {
   name: string | null;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFieldsNestedAgain {
   name: string | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -381,20 +435,24 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -406,20 +464,24 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   a: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   a: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   b: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   b: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -430,25 +492,33 @@ Array [
   Object {
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
-  heroNoParam: {
-    name: string | null;
-  } & IFragmentCharacterFields | null;
-}",
+  heroNoParam:
+    | {
+        name: string | null;
+      } & IFragmentCharacterFields
+    | null;
+}
+",
     "result": "export interface FragmentTest {
-  heroNoParam: {
-    name: string | null;
-  } & IFragmentCharacterFields | null;
-}",
+  heroNoParam:
+    | {
+        name: string | null;
+      } & IFragmentCharacterFields
+    | null;
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -459,25 +529,33 @@ Array [
   Object {
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
-  a: {
-    b: string | null;
-  } & IFragmentCharacterFields | null;
-}",
+  a:
+    | {
+        b: string | null;
+      } & IFragmentCharacterFields
+    | null;
+}
+",
     "result": "export interface FragmentTest {
-  a: {
-    b: string | null;
-  } & IFragmentCharacterFields | null;
-}",
+  a:
+    | {
+        b: string | null;
+      } & IFragmentCharacterFields
+    | null;
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   c: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   c: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -492,13 +570,15 @@ Array [
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface Anonymous {
   heroNoParam: {
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -513,13 +593,15 @@ Array [
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface TestQuery {
   heroNoParam: {
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -535,14 +617,16 @@ Array [
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface TestQuery {
   heroNoParam: {
     __typename: string;
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -557,13 +641,15 @@ Array [
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface Anonymous {
   heroNoParam: {
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -588,7 +674,8 @@ Array [
       name: string | null;
     }> | null;
   } | null;
-}",
+}
+",
     "result": "export interface Test {
   heroNoParam: {
     nonNullArr: Array<{
@@ -604,7 +691,8 @@ Array [
       name: string | null;
     }> | null;
   } | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -616,17 +704,21 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface CustomScalarQuery {
   test: string | null;
-}",
+}
+",
     "result": "export interface CustomScalarQueryInput {
   test?: string | null;
 }
 
+
 export interface CustomScalarQuery {
   test: string | null;
-}",
+}
+",
     "variables": "export interface CustomScalarQueryInput {
   test?: string | null;
-}",
+}
+",
   },
 ]
 `;
@@ -639,19 +731,23 @@ Array [
   hero: {
     appearsIn: Array<'NEWHOPE' | 'EMPIRE' | 'JEDI' | null> | null;
   } | null;
-}",
+}
+",
     "result": "export interface EnumQueryInput {
   episode?: 'NEWHOPE' | 'EMPIRE' | 'JEDI' | null;
 }
+
 
 export interface EnumQuery {
   hero: {
     appearsIn: Array<'NEWHOPE' | 'EMPIRE' | 'JEDI' | null> | null;
   } | null;
-}",
+}
+",
     "variables": "export interface EnumQueryInput {
   episode?: 'NEWHOPE' | 'EMPIRE' | 'JEDI' | null;
-}",
+}
+",
   },
 ]
 `;
@@ -665,20 +761,24 @@ Array [
     id: string;
     name: string | null;
   } | null>;
-}",
+}
+",
     "result": "export interface TestQueryInput {
   ids: Array<string>;
 }
+
 
 export interface TestQuery {
   getCharacters: Array<{
     id: string;
     name: string | null;
   } | null>;
-}",
+}
+",
     "variables": "export interface TestQueryInput {
   ids: Array<string>;
-}",
+}
+",
   },
 ]
 `;
@@ -691,19 +791,23 @@ Array [
   humanOrDroid: {
     id: string;
   } | null;
-}",
+}
+",
     "result": "export interface UnionQueryInput {
   id: string;
 }
+
 
 export interface UnionQuery {
   humanOrDroid: {
     id: string;
   } | null;
-}",
+}
+",
     "variables": "export interface UnionQueryInput {
   id: string;
-}",
+}
+",
   },
 ]
 `;
@@ -717,20 +821,24 @@ Array [
     id?: string;
     name?: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface UnionQueryInput {
   id: string;
 }
+
 
 export interface UnionQuery {
   humanOrDroid: {
     id?: string;
     name?: string | null;
   } | null;
-}",
+}
+",
     "variables": "export interface UnionQueryInput {
   id: string;
-}",
+}
+",
   },
 ]
 `;
@@ -744,20 +852,24 @@ Array [
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "result": "export interface TestQueryInput {
   id: string;
 }
+
 
 export interface TestQuery {
   human: {
     id: string;
     name: string | null;
   } | null;
-}",
+}
+",
     "variables": "export interface TestQueryInput {
   id: string;
-}",
+}
+",
   },
 ]
 `;
@@ -769,29 +881,35 @@ Array [
       "export interface SelectionOnFriends {
   id: string;
   name: string | null;
-}",
+}
+",
       "export interface SelectionOnFriends1 {
   id: string;
   name: string | null;
   friends: Array<SelectionOnFriends | null> | null;
-}",
+}
+",
       "export interface SelectionOnFriends2 {
   id: string;
   name: string | null;
   friends: Array<SelectionOnFriends1 | null> | null;
-}",
+}
+",
       "export interface SelectionOnHeroNoParam {
   friends: Array<SelectionOnFriends2 | null> | null;
-}",
+}
+",
     ],
     "interface": "export interface Test {
   hero1: SelectionOnHeroNoParam | null;
   hero2: SelectionOnHeroNoParam | null;
-}",
+}
+",
     "result": "export interface SelectionOnFriends {
   id: string;
   name: string | null;
 }
+
 
 export interface SelectionOnFriends1 {
   id: string;
@@ -799,20 +917,24 @@ export interface SelectionOnFriends1 {
   friends: Array<SelectionOnFriends | null> | null;
 }
 
+
 export interface SelectionOnFriends2 {
   id: string;
   name: string | null;
   friends: Array<SelectionOnFriends1 | null> | null;
 }
 
+
 export interface SelectionOnHeroNoParam {
   friends: Array<SelectionOnFriends2 | null> | null;
 }
 
+
 export interface Test {
   hero1: SelectionOnHeroNoParam | null;
   hero2: SelectionOnHeroNoParam | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -825,19 +947,23 @@ Array [
       "export interface SelectionOnHeroNoParam {
   id: string;
   name: string | null;
-}",
+}
+",
     ],
     "interface": "export interface TestQuery {
   heroNoParam: SelectionOnHeroNoParam | null;
-}",
+}
+",
     "result": "export interface SelectionOnHeroNoParam {
   id: string;
   name: string | null;
 }
 
+
 export interface TestQuery {
   heroNoParam: SelectionOnHeroNoParam | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -850,38 +976,46 @@ Array [
       "export interface SelectionOnNonNullArr {
   id: string;
   name: string | null;
-}",
+}
+",
       "export interface SelectionOnNonNullArrAndContents {
   id: string;
   name: string | null;
-}",
+}
+",
       "export interface SelectionOnNullArrNonNullContents {
   id: string;
   name: string | null;
-}",
+}
+",
       "export interface SelectionOnHeroNoParam {
   nonNullArr: Array<SelectionOnNonNullArr | null>;
   nonNullArrAndContents: Array<SelectionOnNonNullArrAndContents>;
   nullArrNonNullContents: Array<SelectionOnNullArrNonNullContents> | null;
-}",
+}
+",
     ],
     "interface": "export interface Test {
   heroNoParam: SelectionOnHeroNoParam | null;
-}",
+}
+",
     "result": "export interface SelectionOnNonNullArr {
   id: string;
   name: string | null;
 }
+
 
 export interface SelectionOnNonNullArrAndContents {
   id: string;
   name: string | null;
 }
 
+
 export interface SelectionOnNullArrNonNullContents {
   id: string;
   name: string | null;
 }
+
 
 export interface SelectionOnHeroNoParam {
   nonNullArr: Array<SelectionOnNonNullArr | null>;
@@ -889,9 +1023,11 @@ export interface SelectionOnHeroNoParam {
   nullArrNonNullContents: Array<SelectionOnNullArrNonNullContents> | null;
 }
 
+
 export interface Test {
   heroNoParam: SelectionOnHeroNoParam | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -903,20 +1039,24 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [],
     "interface": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   id: string;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -928,10 +1068,12 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
@@ -939,11 +1081,13 @@ Array [
     "interface": "export interface IFragmentCharacterFields {
   id: string;
   name?: string | null;
-}",
+}
+",
     "result": "export interface IFragmentCharacterFields {
   id: string;
   name?: string | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -955,32 +1099,38 @@ Array [
     "additionalTypes": Array [],
     "interface": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export interface FragmentTest {
   heroNoParam: IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [
       "export interface SelectionOnFriends {
   id: string;
-}",
+}
+",
     ],
     "interface": "export interface IFragmentCharacterFields {
   id: string;
   name?: string | null;
   friends?: Array<SelectionOnFriends | null> | null;
-}",
+}
+",
     "result": "export interface SelectionOnFriends {
   id: string;
 }
+
 
 export interface IFragmentCharacterFields {
   id: string;
   name?: string | null;
   friends?: Array<SelectionOnFriends | null> | null;
-}",
+}
+",
     "variables": "",
   },
 ]
@@ -992,40 +1142,48 @@ Array [
     "additionalTypes": Array [
       "export type SelectionOnHeroNoParam = Partial<{
   name?: string | null;
-}>",
+}>;
+",
     ],
     "interface": "export interface FragmentTest {
   heroNoParam: SelectionOnHeroNoParam & IFragmentCharacterFields | null;
-}",
+}
+",
     "result": "export type SelectionOnHeroNoParam = Partial<{
   name?: string | null;
-}>
+}>;
+
 
 export interface FragmentTest {
   heroNoParam: SelectionOnHeroNoParam & IFragmentCharacterFields | null;
-}",
+}
+",
     "variables": "",
   },
   Object {
     "additionalTypes": Array [
       "export interface SelectionOnFriends {
   id: string;
-}",
+}
+",
     ],
     "interface": "export interface IFragmentCharacterFields {
   id: string;
   name?: string | null;
   friends?: Array<SelectionOnFriends | null> | null;
-}",
+}
+",
     "result": "export interface SelectionOnFriends {
   id: string;
 }
+
 
 export interface IFragmentCharacterFields {
   id: string;
   name?: string | null;
   friends?: Array<SelectionOnFriends | null> | null;
-}",
+}
+",
     "variables": "",
   },
 ]

--- a/__tests__/__snapshots__/from-schema-test.ts.snap
+++ b/__tests__/__snapshots__/from-schema-test.ts.snap
@@ -4457,9 +4457,9 @@ declare namespace GQL {
   }
 
   interface IGraphQLResponseError {
-    message: string;            // Required for all errors
+    message: string; // Required for all errors
     locations?: Array<IGraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+    [propName: string]: any; // 7.2.2 says 'GraphQL servers may provide additional entries to error'
   }
 
   interface IGraphQLResponseErrorLocation {
@@ -4467,9 +4467,8 @@ declare namespace GQL {
     column: number;
   }
 
-
   interface IRoot {
-    __typename: \\"Root\\";
+    __typename: 'Root';
     allFilms: IFilmsConnection | null;
     film: IFilm | null;
     allPeople: IPeopleConnection | null;
@@ -4492,7 +4491,7 @@ declare namespace GQL {
     A connection to a list of items.
   */
   interface IFilmsConnection {
-    __typename: \\"FilmsConnection\\";
+    __typename: 'FilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -4523,7 +4522,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     Information about pagination in a connection.
   */
   interface IPageInfo {
-    __typename: \\"PageInfo\\";
+    __typename: 'PageInfo';
     /**
     When paginating forwards, are there more items?
   */
@@ -4546,7 +4545,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmsEdge {
-    __typename: \\"FilmsEdge\\";
+    __typename: 'FilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -4561,7 +4560,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single film.
   */
   interface IFilm {
-    __typename: \\"Film\\";
+    __typename: 'Film';
     /**
     The title of this film.
   */
@@ -4614,7 +4613,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An object with an ID
   */
   interface INode {
-    __typename: \\"Node\\";
+    __typename: 'Node';
     /**
     The id of the object.
   */
@@ -4625,7 +4624,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmSpeciesConnection {
-    __typename: \\"FilmSpeciesConnection\\";
+    __typename: 'FilmSpeciesConnection';
     /**
     Information to aid in pagination.
   */
@@ -4656,7 +4655,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmSpeciesEdge {
-    __typename: \\"FilmSpeciesEdge\\";
+    __typename: 'FilmSpeciesEdge';
     /**
     The item at the end of the edge
   */
@@ -4671,7 +4670,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A type of person or character within the Star Wars Universe.
   */
   interface ISpecies {
-    __typename: \\"Species\\";
+    __typename: 'Species';
     /**
     The name of this species.
   */
@@ -4736,7 +4735,7 @@ have skin.
 0 ABY.
   */
   interface IPlanet {
-    __typename: \\"Planet\\";
+    __typename: 'Planet';
     /**
     The name of this planet.
   */
@@ -4797,7 +4796,7 @@ of water.
     A connection to a list of items.
   */
   interface IPlanetResidentsConnection {
-    __typename: \\"PlanetResidentsConnection\\";
+    __typename: 'PlanetResidentsConnection';
     /**
     Information to aid in pagination.
   */
@@ -4828,7 +4827,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetResidentsEdge {
-    __typename: \\"PlanetResidentsEdge\\";
+    __typename: 'PlanetResidentsEdge';
     /**
     The item at the end of the edge
   */
@@ -4843,7 +4842,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An individual person or character within the Star Wars universe.
   */
   interface IPerson {
-    __typename: \\"Person\\";
+    __typename: 'Person';
     /**
     The name of this person.
   */
@@ -4910,7 +4909,7 @@ person does not have hair.
     A connection to a list of items.
   */
   interface IPersonFilmsConnection {
-    __typename: \\"PersonFilmsConnection\\";
+    __typename: 'PersonFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -4941,7 +4940,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonFilmsEdge {
-    __typename: \\"PersonFilmsEdge\\";
+    __typename: 'PersonFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -4956,7 +4955,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPersonStarshipsConnection {
-    __typename: \\"PersonStarshipsConnection\\";
+    __typename: 'PersonStarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -4987,7 +4986,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonStarshipsEdge {
-    __typename: \\"PersonStarshipsEdge\\";
+    __typename: 'PersonStarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -5002,7 +5001,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single transport craft that has hyperdrive capability.
   */
   interface IStarship {
-    __typename: \\"Starship\\";
+    __typename: 'Starship';
     /**
     The name of this starship. The common name, such as \\"Death Star\\".
   */
@@ -5083,7 +5082,7 @@ entire crew without having to resupply.
     A connection to a list of items.
   */
   interface IStarshipPilotsConnection {
-    __typename: \\"StarshipPilotsConnection\\";
+    __typename: 'StarshipPilotsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5114,7 +5113,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipPilotsEdge {
-    __typename: \\"StarshipPilotsEdge\\";
+    __typename: 'StarshipPilotsEdge';
     /**
     The item at the end of the edge
   */
@@ -5129,7 +5128,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IStarshipFilmsConnection {
-    __typename: \\"StarshipFilmsConnection\\";
+    __typename: 'StarshipFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5160,7 +5159,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipFilmsEdge {
-    __typename: \\"StarshipFilmsEdge\\";
+    __typename: 'StarshipFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -5175,7 +5174,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPersonVehiclesConnection {
-    __typename: \\"PersonVehiclesConnection\\";
+    __typename: 'PersonVehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -5206,7 +5205,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonVehiclesEdge {
-    __typename: \\"PersonVehiclesEdge\\";
+    __typename: 'PersonVehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -5221,7 +5220,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single transport craft that does not have hyperdrive capability
   */
   interface IVehicle {
-    __typename: \\"Vehicle\\";
+    __typename: 'Vehicle';
     /**
     The name of this vehicle. The common name, such as \\"Sand Crawler\\" or \\"Speeder
 bike\\".
@@ -5289,7 +5288,7 @@ entire crew without having to resupply.
     A connection to a list of items.
   */
   interface IVehiclePilotsConnection {
-    __typename: \\"VehiclePilotsConnection\\";
+    __typename: 'VehiclePilotsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5320,7 +5319,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehiclePilotsEdge {
-    __typename: \\"VehiclePilotsEdge\\";
+    __typename: 'VehiclePilotsEdge';
     /**
     The item at the end of the edge
   */
@@ -5335,7 +5334,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IVehicleFilmsConnection {
-    __typename: \\"VehicleFilmsConnection\\";
+    __typename: 'VehicleFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5366,7 +5365,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehicleFilmsEdge {
-    __typename: \\"VehicleFilmsEdge\\";
+    __typename: 'VehicleFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -5381,7 +5380,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPlanetFilmsConnection {
-    __typename: \\"PlanetFilmsConnection\\";
+    __typename: 'PlanetFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5412,7 +5411,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetFilmsEdge {
-    __typename: \\"PlanetFilmsEdge\\";
+    __typename: 'PlanetFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -5427,7 +5426,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesPeopleConnection {
-    __typename: \\"SpeciesPeopleConnection\\";
+    __typename: 'SpeciesPeopleConnection';
     /**
     Information to aid in pagination.
   */
@@ -5458,7 +5457,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesPeopleEdge {
-    __typename: \\"SpeciesPeopleEdge\\";
+    __typename: 'SpeciesPeopleEdge';
     /**
     The item at the end of the edge
   */
@@ -5473,7 +5472,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesFilmsConnection {
-    __typename: \\"SpeciesFilmsConnection\\";
+    __typename: 'SpeciesFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5504,7 +5503,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesFilmsEdge {
-    __typename: \\"SpeciesFilmsEdge\\";
+    __typename: 'SpeciesFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -5519,7 +5518,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmStarshipsConnection {
-    __typename: \\"FilmStarshipsConnection\\";
+    __typename: 'FilmStarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5550,7 +5549,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmStarshipsEdge {
-    __typename: \\"FilmStarshipsEdge\\";
+    __typename: 'FilmStarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -5565,7 +5564,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmVehiclesConnection {
-    __typename: \\"FilmVehiclesConnection\\";
+    __typename: 'FilmVehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -5596,7 +5595,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmVehiclesEdge {
-    __typename: \\"FilmVehiclesEdge\\";
+    __typename: 'FilmVehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -5611,7 +5610,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmCharactersConnection {
-    __typename: \\"FilmCharactersConnection\\";
+    __typename: 'FilmCharactersConnection';
     /**
     Information to aid in pagination.
   */
@@ -5642,7 +5641,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmCharactersEdge {
-    __typename: \\"FilmCharactersEdge\\";
+    __typename: 'FilmCharactersEdge';
     /**
     The item at the end of the edge
   */
@@ -5657,7 +5656,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmPlanetsConnection {
-    __typename: \\"FilmPlanetsConnection\\";
+    __typename: 'FilmPlanetsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5688,7 +5687,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmPlanetsEdge {
-    __typename: \\"FilmPlanetsEdge\\";
+    __typename: 'FilmPlanetsEdge';
     /**
     The item at the end of the edge
   */
@@ -5703,7 +5702,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPeopleConnection {
-    __typename: \\"PeopleConnection\\";
+    __typename: 'PeopleConnection';
     /**
     Information to aid in pagination.
   */
@@ -5734,7 +5733,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPeopleEdge {
-    __typename: \\"PeopleEdge\\";
+    __typename: 'PeopleEdge';
     /**
     The item at the end of the edge
   */
@@ -5749,7 +5748,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPlanetsConnection {
-    __typename: \\"PlanetsConnection\\";
+    __typename: 'PlanetsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5780,7 +5779,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetsEdge {
-    __typename: \\"PlanetsEdge\\";
+    __typename: 'PlanetsEdge';
     /**
     The item at the end of the edge
   */
@@ -5795,7 +5794,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesConnection {
-    __typename: \\"SpeciesConnection\\";
+    __typename: 'SpeciesConnection';
     /**
     Information to aid in pagination.
   */
@@ -5826,7 +5825,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesEdge {
-    __typename: \\"SpeciesEdge\\";
+    __typename: 'SpeciesEdge';
     /**
     The item at the end of the edge
   */
@@ -5841,7 +5840,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IStarshipsConnection {
-    __typename: \\"StarshipsConnection\\";
+    __typename: 'StarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -5872,7 +5871,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipsEdge {
-    __typename: \\"StarshipsEdge\\";
+    __typename: 'StarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -5887,7 +5886,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IVehiclesConnection {
-    __typename: \\"VehiclesConnection\\";
+    __typename: 'VehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -5918,7 +5917,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehiclesEdge {
-    __typename: \\"VehiclesEdge\\";
+    __typename: 'VehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -5945,9 +5944,9 @@ declare namespace GQL {
   }
 
   interface IGraphQLResponseError {
-    message: string;            // Required for all errors
+    message: string; // Required for all errors
     locations?: Array<IGraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+    [propName: string]: any; // 7.2.2 says 'GraphQL servers may provide additional entries to error'
   }
 
   interface IGraphQLResponseErrorLocation {
@@ -5955,12 +5954,10 @@ declare namespace GQL {
     column: number;
   }
 
-
   interface IQuery {
-    __typename: \\"Query\\";
+    __typename: 'Query';
     colorEnum: IColorEnum | null;
   }
-
 
   type IColorEnum = 'RED' | 'GREEN' | 'BLUE';
 }
@@ -5980,9 +5977,9 @@ declare namespace StarWars {
   }
 
   interface IGraphQLResponseError {
-    message: string;            // Required for all errors
+    message: string; // Required for all errors
     locations?: Array<IGraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+    [propName: string]: any; // 7.2.2 says 'GraphQL servers may provide additional entries to error'
   }
 
   interface IGraphQLResponseErrorLocation {
@@ -5990,9 +5987,8 @@ declare namespace StarWars {
     column: number;
   }
 
-
   interface IRoot {
-    __typename: \\"Root\\";
+    __typename: 'Root';
     allFilms: IFilmsConnection | null;
     film: IFilm | null;
     allPeople: IPeopleConnection | null;
@@ -6015,7 +6011,7 @@ declare namespace StarWars {
     A connection to a list of items.
   */
   interface IFilmsConnection {
-    __typename: \\"FilmsConnection\\";
+    __typename: 'FilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6046,7 +6042,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     Information about pagination in a connection.
   */
   interface IPageInfo {
-    __typename: \\"PageInfo\\";
+    __typename: 'PageInfo';
     /**
     When paginating forwards, are there more items?
   */
@@ -6069,7 +6065,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmsEdge {
-    __typename: \\"FilmsEdge\\";
+    __typename: 'FilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -6084,7 +6080,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single film.
   */
   interface IFilm {
-    __typename: \\"Film\\";
+    __typename: 'Film';
     /**
     The title of this film.
   */
@@ -6137,7 +6133,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An object with an ID
   */
   interface INode {
-    __typename: \\"Node\\";
+    __typename: 'Node';
     /**
     The id of the object.
   */
@@ -6148,7 +6144,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmSpeciesConnection {
-    __typename: \\"FilmSpeciesConnection\\";
+    __typename: 'FilmSpeciesConnection';
     /**
     Information to aid in pagination.
   */
@@ -6179,7 +6175,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmSpeciesEdge {
-    __typename: \\"FilmSpeciesEdge\\";
+    __typename: 'FilmSpeciesEdge';
     /**
     The item at the end of the edge
   */
@@ -6194,7 +6190,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A type of person or character within the Star Wars Universe.
   */
   interface ISpecies {
-    __typename: \\"Species\\";
+    __typename: 'Species';
     /**
     The name of this species.
   */
@@ -6259,7 +6255,7 @@ have skin.
 0 ABY.
   */
   interface IPlanet {
-    __typename: \\"Planet\\";
+    __typename: 'Planet';
     /**
     The name of this planet.
   */
@@ -6320,7 +6316,7 @@ of water.
     A connection to a list of items.
   */
   interface IPlanetResidentsConnection {
-    __typename: \\"PlanetResidentsConnection\\";
+    __typename: 'PlanetResidentsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6351,7 +6347,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetResidentsEdge {
-    __typename: \\"PlanetResidentsEdge\\";
+    __typename: 'PlanetResidentsEdge';
     /**
     The item at the end of the edge
   */
@@ -6366,7 +6362,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An individual person or character within the Star Wars universe.
   */
   interface IPerson {
-    __typename: \\"Person\\";
+    __typename: 'Person';
     /**
     The name of this person.
   */
@@ -6433,7 +6429,7 @@ person does not have hair.
     A connection to a list of items.
   */
   interface IPersonFilmsConnection {
-    __typename: \\"PersonFilmsConnection\\";
+    __typename: 'PersonFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6464,7 +6460,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonFilmsEdge {
-    __typename: \\"PersonFilmsEdge\\";
+    __typename: 'PersonFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -6479,7 +6475,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPersonStarshipsConnection {
-    __typename: \\"PersonStarshipsConnection\\";
+    __typename: 'PersonStarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6510,7 +6506,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonStarshipsEdge {
-    __typename: \\"PersonStarshipsEdge\\";
+    __typename: 'PersonStarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -6525,7 +6521,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single transport craft that has hyperdrive capability.
   */
   interface IStarship {
-    __typename: \\"Starship\\";
+    __typename: 'Starship';
     /**
     The name of this starship. The common name, such as \\"Death Star\\".
   */
@@ -6606,7 +6602,7 @@ entire crew without having to resupply.
     A connection to a list of items.
   */
   interface IStarshipPilotsConnection {
-    __typename: \\"StarshipPilotsConnection\\";
+    __typename: 'StarshipPilotsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6637,7 +6633,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipPilotsEdge {
-    __typename: \\"StarshipPilotsEdge\\";
+    __typename: 'StarshipPilotsEdge';
     /**
     The item at the end of the edge
   */
@@ -6652,7 +6648,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IStarshipFilmsConnection {
-    __typename: \\"StarshipFilmsConnection\\";
+    __typename: 'StarshipFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6683,7 +6679,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipFilmsEdge {
-    __typename: \\"StarshipFilmsEdge\\";
+    __typename: 'StarshipFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -6698,7 +6694,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPersonVehiclesConnection {
-    __typename: \\"PersonVehiclesConnection\\";
+    __typename: 'PersonVehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -6729,7 +6725,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonVehiclesEdge {
-    __typename: \\"PersonVehiclesEdge\\";
+    __typename: 'PersonVehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -6744,7 +6740,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single transport craft that does not have hyperdrive capability
   */
   interface IVehicle {
-    __typename: \\"Vehicle\\";
+    __typename: 'Vehicle';
     /**
     The name of this vehicle. The common name, such as \\"Sand Crawler\\" or \\"Speeder
 bike\\".
@@ -6812,7 +6808,7 @@ entire crew without having to resupply.
     A connection to a list of items.
   */
   interface IVehiclePilotsConnection {
-    __typename: \\"VehiclePilotsConnection\\";
+    __typename: 'VehiclePilotsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6843,7 +6839,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehiclePilotsEdge {
-    __typename: \\"VehiclePilotsEdge\\";
+    __typename: 'VehiclePilotsEdge';
     /**
     The item at the end of the edge
   */
@@ -6858,7 +6854,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IVehicleFilmsConnection {
-    __typename: \\"VehicleFilmsConnection\\";
+    __typename: 'VehicleFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6889,7 +6885,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehicleFilmsEdge {
-    __typename: \\"VehicleFilmsEdge\\";
+    __typename: 'VehicleFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -6904,7 +6900,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPlanetFilmsConnection {
-    __typename: \\"PlanetFilmsConnection\\";
+    __typename: 'PlanetFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -6935,7 +6931,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetFilmsEdge {
-    __typename: \\"PlanetFilmsEdge\\";
+    __typename: 'PlanetFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -6950,7 +6946,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesPeopleConnection {
-    __typename: \\"SpeciesPeopleConnection\\";
+    __typename: 'SpeciesPeopleConnection';
     /**
     Information to aid in pagination.
   */
@@ -6981,7 +6977,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesPeopleEdge {
-    __typename: \\"SpeciesPeopleEdge\\";
+    __typename: 'SpeciesPeopleEdge';
     /**
     The item at the end of the edge
   */
@@ -6996,7 +6992,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesFilmsConnection {
-    __typename: \\"SpeciesFilmsConnection\\";
+    __typename: 'SpeciesFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7027,7 +7023,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesFilmsEdge {
-    __typename: \\"SpeciesFilmsEdge\\";
+    __typename: 'SpeciesFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -7042,7 +7038,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmStarshipsConnection {
-    __typename: \\"FilmStarshipsConnection\\";
+    __typename: 'FilmStarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7073,7 +7069,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmStarshipsEdge {
-    __typename: \\"FilmStarshipsEdge\\";
+    __typename: 'FilmStarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -7088,7 +7084,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmVehiclesConnection {
-    __typename: \\"FilmVehiclesConnection\\";
+    __typename: 'FilmVehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -7119,7 +7115,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmVehiclesEdge {
-    __typename: \\"FilmVehiclesEdge\\";
+    __typename: 'FilmVehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -7134,7 +7130,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmCharactersConnection {
-    __typename: \\"FilmCharactersConnection\\";
+    __typename: 'FilmCharactersConnection';
     /**
     Information to aid in pagination.
   */
@@ -7165,7 +7161,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmCharactersEdge {
-    __typename: \\"FilmCharactersEdge\\";
+    __typename: 'FilmCharactersEdge';
     /**
     The item at the end of the edge
   */
@@ -7180,7 +7176,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmPlanetsConnection {
-    __typename: \\"FilmPlanetsConnection\\";
+    __typename: 'FilmPlanetsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7211,7 +7207,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmPlanetsEdge {
-    __typename: \\"FilmPlanetsEdge\\";
+    __typename: 'FilmPlanetsEdge';
     /**
     The item at the end of the edge
   */
@@ -7226,7 +7222,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPeopleConnection {
-    __typename: \\"PeopleConnection\\";
+    __typename: 'PeopleConnection';
     /**
     Information to aid in pagination.
   */
@@ -7257,7 +7253,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPeopleEdge {
-    __typename: \\"PeopleEdge\\";
+    __typename: 'PeopleEdge';
     /**
     The item at the end of the edge
   */
@@ -7272,7 +7268,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPlanetsConnection {
-    __typename: \\"PlanetsConnection\\";
+    __typename: 'PlanetsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7303,7 +7299,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetsEdge {
-    __typename: \\"PlanetsEdge\\";
+    __typename: 'PlanetsEdge';
     /**
     The item at the end of the edge
   */
@@ -7318,7 +7314,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesConnection {
-    __typename: \\"SpeciesConnection\\";
+    __typename: 'SpeciesConnection';
     /**
     Information to aid in pagination.
   */
@@ -7349,7 +7345,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesEdge {
-    __typename: \\"SpeciesEdge\\";
+    __typename: 'SpeciesEdge';
     /**
     The item at the end of the edge
   */
@@ -7364,7 +7360,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IStarshipsConnection {
-    __typename: \\"StarshipsConnection\\";
+    __typename: 'StarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7395,7 +7391,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipsEdge {
-    __typename: \\"StarshipsEdge\\";
+    __typename: 'StarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -7410,7 +7406,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IVehiclesConnection {
-    __typename: \\"VehiclesConnection\\";
+    __typename: 'VehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -7441,7 +7437,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehiclesEdge {
-    __typename: \\"VehiclesEdge\\";
+    __typename: 'VehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -7468,9 +7464,9 @@ declare namespace StarWars {
   }
 
   interface IGraphQLResponseError {
-    message: string;            // Required for all errors
+    message: string; // Required for all errors
     locations?: Array<IGraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+    [propName: string]: any; // 7.2.2 says 'GraphQL servers may provide additional entries to error'
   }
 
   interface IGraphQLResponseErrorLocation {
@@ -7478,9 +7474,8 @@ declare namespace StarWars {
     column: number;
   }
 
-
   interface IRoot {
-    __typename: \\"Root\\";
+    __typename: 'Root';
     allFilms: IFilmsConnection | null;
     film: IFilm | null;
     allPeople: IPeopleConnection | null;
@@ -7502,7 +7497,7 @@ declare namespace StarWars {
     A connection to a list of items.
   */
   interface IFilmsConnection {
-    __typename: \\"FilmsConnection\\";
+    __typename: 'FilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7533,7 +7528,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     Information about pagination in a connection.
   */
   interface IPageInfo {
-    __typename: \\"PageInfo\\";
+    __typename: 'PageInfo';
     /**
     When paginating forwards, are there more items?
   */
@@ -7556,7 +7551,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmsEdge {
-    __typename: \\"FilmsEdge\\";
+    __typename: 'FilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -7571,7 +7566,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single film.
   */
   interface IFilm {
-    __typename: \\"Film\\";
+    __typename: 'Film';
     /**
     The title of this film.
   */
@@ -7624,7 +7619,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An object with an ID
   */
   interface INode {
-    __typename: \\"Node\\";
+    __typename: 'Node';
     /**
     The id of the object.
   */
@@ -7635,7 +7630,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmSpeciesConnection {
-    __typename: \\"FilmSpeciesConnection\\";
+    __typename: 'FilmSpeciesConnection';
     /**
     Information to aid in pagination.
   */
@@ -7666,7 +7661,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmSpeciesEdge {
-    __typename: \\"FilmSpeciesEdge\\";
+    __typename: 'FilmSpeciesEdge';
     /**
     The item at the end of the edge
   */
@@ -7681,7 +7676,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A type of person or character within the Star Wars Universe.
   */
   interface ISpecies {
-    __typename: \\"Species\\";
+    __typename: 'Species';
     /**
     The name of this species.
   */
@@ -7746,7 +7741,7 @@ have skin.
 0 ABY.
   */
   interface IPlanet {
-    __typename: \\"Planet\\";
+    __typename: 'Planet';
     /**
     The name of this planet.
   */
@@ -7807,7 +7802,7 @@ of water.
     A connection to a list of items.
   */
   interface IPlanetResidentsConnection {
-    __typename: \\"PlanetResidentsConnection\\";
+    __typename: 'PlanetResidentsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7829,7 +7824,7 @@ for example.
     An edge in a connection.
   */
   interface IPlanetResidentsEdge {
-    __typename: \\"PlanetResidentsEdge\\";
+    __typename: 'PlanetResidentsEdge';
     /**
     A cursor for use in pagination
   */
@@ -7840,7 +7835,7 @@ for example.
     A connection to a list of items.
   */
   interface IPersonFilmsConnection {
-    __typename: \\"PersonFilmsConnection\\";
+    __typename: 'PersonFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7871,7 +7866,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonFilmsEdge {
-    __typename: \\"PersonFilmsEdge\\";
+    __typename: 'PersonFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -7886,7 +7881,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPersonStarshipsConnection {
-    __typename: \\"PersonStarshipsConnection\\";
+    __typename: 'PersonStarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -7917,7 +7912,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonStarshipsEdge {
-    __typename: \\"PersonStarshipsEdge\\";
+    __typename: 'PersonStarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -7932,7 +7927,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single transport craft that has hyperdrive capability.
   */
   interface IStarship {
-    __typename: \\"Starship\\";
+    __typename: 'Starship';
     /**
     The name of this starship. The common name, such as \\"Death Star\\".
   */
@@ -8013,7 +8008,7 @@ entire crew without having to resupply.
     A connection to a list of items.
   */
   interface IStarshipPilotsConnection {
-    __typename: \\"StarshipPilotsConnection\\";
+    __typename: 'StarshipPilotsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8035,7 +8030,7 @@ for example.
     An edge in a connection.
   */
   interface IStarshipPilotsEdge {
-    __typename: \\"StarshipPilotsEdge\\";
+    __typename: 'StarshipPilotsEdge';
     /**
     A cursor for use in pagination
   */
@@ -8046,7 +8041,7 @@ for example.
     A connection to a list of items.
   */
   interface IStarshipFilmsConnection {
-    __typename: \\"StarshipFilmsConnection\\";
+    __typename: 'StarshipFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8077,7 +8072,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipFilmsEdge {
-    __typename: \\"StarshipFilmsEdge\\";
+    __typename: 'StarshipFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -8092,7 +8087,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPersonVehiclesConnection {
-    __typename: \\"PersonVehiclesConnection\\";
+    __typename: 'PersonVehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -8123,7 +8118,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPersonVehiclesEdge {
-    __typename: \\"PersonVehiclesEdge\\";
+    __typename: 'PersonVehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -8138,7 +8133,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A single transport craft that does not have hyperdrive capability
   */
   interface IVehicle {
-    __typename: \\"Vehicle\\";
+    __typename: 'Vehicle';
     /**
     The name of this vehicle. The common name, such as \\"Sand Crawler\\" or \\"Speeder
 bike\\".
@@ -8206,7 +8201,7 @@ entire crew without having to resupply.
     A connection to a list of items.
   */
   interface IVehiclePilotsConnection {
-    __typename: \\"VehiclePilotsConnection\\";
+    __typename: 'VehiclePilotsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8228,7 +8223,7 @@ for example.
     An edge in a connection.
   */
   interface IVehiclePilotsEdge {
-    __typename: \\"VehiclePilotsEdge\\";
+    __typename: 'VehiclePilotsEdge';
     /**
     A cursor for use in pagination
   */
@@ -8239,7 +8234,7 @@ for example.
     A connection to a list of items.
   */
   interface IVehicleFilmsConnection {
-    __typename: \\"VehicleFilmsConnection\\";
+    __typename: 'VehicleFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8270,7 +8265,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehicleFilmsEdge {
-    __typename: \\"VehicleFilmsEdge\\";
+    __typename: 'VehicleFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -8285,7 +8280,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPlanetFilmsConnection {
-    __typename: \\"PlanetFilmsConnection\\";
+    __typename: 'PlanetFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8316,7 +8311,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetFilmsEdge {
-    __typename: \\"PlanetFilmsEdge\\";
+    __typename: 'PlanetFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -8331,7 +8326,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesPeopleConnection {
-    __typename: \\"SpeciesPeopleConnection\\";
+    __typename: 'SpeciesPeopleConnection';
     /**
     Information to aid in pagination.
   */
@@ -8353,7 +8348,7 @@ for example.
     An edge in a connection.
   */
   interface ISpeciesPeopleEdge {
-    __typename: \\"SpeciesPeopleEdge\\";
+    __typename: 'SpeciesPeopleEdge';
     /**
     A cursor for use in pagination
   */
@@ -8364,7 +8359,7 @@ for example.
     A connection to a list of items.
   */
   interface ISpeciesFilmsConnection {
-    __typename: \\"SpeciesFilmsConnection\\";
+    __typename: 'SpeciesFilmsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8395,7 +8390,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesFilmsEdge {
-    __typename: \\"SpeciesFilmsEdge\\";
+    __typename: 'SpeciesFilmsEdge';
     /**
     The item at the end of the edge
   */
@@ -8410,7 +8405,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmStarshipsConnection {
-    __typename: \\"FilmStarshipsConnection\\";
+    __typename: 'FilmStarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8441,7 +8436,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmStarshipsEdge {
-    __typename: \\"FilmStarshipsEdge\\";
+    __typename: 'FilmStarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -8456,7 +8451,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmVehiclesConnection {
-    __typename: \\"FilmVehiclesConnection\\";
+    __typename: 'FilmVehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -8487,7 +8482,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmVehiclesEdge {
-    __typename: \\"FilmVehiclesEdge\\";
+    __typename: 'FilmVehiclesEdge';
     /**
     The item at the end of the edge
   */
@@ -8502,7 +8497,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IFilmCharactersConnection {
-    __typename: \\"FilmCharactersConnection\\";
+    __typename: 'FilmCharactersConnection';
     /**
     Information to aid in pagination.
   */
@@ -8524,7 +8519,7 @@ for example.
     An edge in a connection.
   */
   interface IFilmCharactersEdge {
-    __typename: \\"FilmCharactersEdge\\";
+    __typename: 'FilmCharactersEdge';
     /**
     A cursor for use in pagination
   */
@@ -8535,7 +8530,7 @@ for example.
     A connection to a list of items.
   */
   interface IFilmPlanetsConnection {
-    __typename: \\"FilmPlanetsConnection\\";
+    __typename: 'FilmPlanetsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8566,7 +8561,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IFilmPlanetsEdge {
-    __typename: \\"FilmPlanetsEdge\\";
+    __typename: 'FilmPlanetsEdge';
     /**
     The item at the end of the edge
   */
@@ -8581,7 +8576,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IPeopleConnection {
-    __typename: \\"PeopleConnection\\";
+    __typename: 'PeopleConnection';
     /**
     Information to aid in pagination.
   */
@@ -8603,7 +8598,7 @@ for example.
     An edge in a connection.
   */
   interface IPeopleEdge {
-    __typename: \\"PeopleEdge\\";
+    __typename: 'PeopleEdge';
     /**
     A cursor for use in pagination
   */
@@ -8614,7 +8609,7 @@ for example.
     A connection to a list of items.
   */
   interface IPlanetsConnection {
-    __typename: \\"PlanetsConnection\\";
+    __typename: 'PlanetsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8645,7 +8640,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IPlanetsEdge {
-    __typename: \\"PlanetsEdge\\";
+    __typename: 'PlanetsEdge';
     /**
     The item at the end of the edge
   */
@@ -8660,7 +8655,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface ISpeciesConnection {
-    __typename: \\"SpeciesConnection\\";
+    __typename: 'SpeciesConnection';
     /**
     Information to aid in pagination.
   */
@@ -8691,7 +8686,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface ISpeciesEdge {
-    __typename: \\"SpeciesEdge\\";
+    __typename: 'SpeciesEdge';
     /**
     The item at the end of the edge
   */
@@ -8706,7 +8701,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IStarshipsConnection {
-    __typename: \\"StarshipsConnection\\";
+    __typename: 'StarshipsConnection';
     /**
     Information to aid in pagination.
   */
@@ -8737,7 +8732,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IStarshipsEdge {
-    __typename: \\"StarshipsEdge\\";
+    __typename: 'StarshipsEdge';
     /**
     The item at the end of the edge
   */
@@ -8752,7 +8747,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     A connection to a list of items.
   */
   interface IVehiclesConnection {
-    __typename: \\"VehiclesConnection\\";
+    __typename: 'VehiclesConnection';
     /**
     Information to aid in pagination.
   */
@@ -8783,7 +8778,7 @@ full \\"{ edges { node } }\\" version should be used instead.
     An edge in a connection.
   */
   interface IVehiclesEdge {
-    __typename: \\"VehiclesEdge\\";
+    __typename: 'VehiclesEdge';
     /**
     The item at the end of the edge
   */

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "description": "Convert GraphQL Schema to TypeScript defs",
   "dependencies": {
-    "graphql": ">= 0.10 <0.12"
+    "graphql": ">= 0.10 <0.12",
+    "prettier": "^1.10.2"
   },
   "devDependencies": {
     "@types/graphql": "^0.11.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lerna": "2.3.1",
     "ts-jest": "^21.0.1",
     "tslint": "^5.5.0",
-    "typescript": "^2.4.1 <2.7.0"
+    "typescript": "^2.4.1"
   },
   "scripts": {
     "pretest": "lerna bootstrap --hoist graphql",

--- a/packages/language-typescript/package.json
+++ b/packages/language-typescript/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@gql2ts/util": "^1.3.0",
     "humps": "^2.0.0",
-    "typescript": "^2.2.2 < 2.7.0"
+    "typescript": "^2.2.2"
   },
   "devDependencies": {
     "@gql2ts/types": "^1.3.0",

--- a/packages/language-typescript/package.json
+++ b/packages/language-typescript/package.json
@@ -9,6 +9,7 @@
   ],
   "typings": "dist/index.d.ts",
   "scripts": {
+    "postinstall": "node postinstall.js",
     "prepublish": "tsc -p tsconfig.json",
     "build:watch": "tsc -w -p tsconfig.json"
   },

--- a/packages/language-typescript/package.json
+++ b/packages/language-typescript/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@gql2ts/types": "^1.3.0",
-    "@types/humps": "^1.1.2"
+    "@types/humps": "^1.1.2",
+    "@types/prettier": "^1.10.0"
   }
 }

--- a/packages/language-typescript/postinstall.js
+++ b/packages/language-typescript/postinstall.js
@@ -1,0 +1,3 @@
+console.log(`Message from @gql2ts/language-typescript:
+  To enable pretty-printing of your code, please install prettier from npm/yarn
+`);

--- a/packages/language-typescript/src/__tests__/__snapshots__/typescriptPrettify-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/typescriptPrettify-test.ts.snap
@@ -1,3 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`typescript prettify prettifies 1`] = `"export interface ITestInterface { a: string; b: string | number; c: string | number | boolean; }"`;
+exports[`typescript prettify prettifies 1`] = `
+"export interface ITestInterface {
+  a: string;
+  b: string | number;
+  c: string | number | boolean;
+}
+"
+`;

--- a/packages/language-typescript/src/typescriptPrettify.ts
+++ b/packages/language-typescript/src/typescriptPrettify.ts
@@ -4,51 +4,23 @@
  * Default Options from:
  *  https://github.com/vvakame/typescript-formatter/tree/a49f0949c9760530365c5b874cf0e979bd010a04#read-settings-from-files
  */
-
-import * as ts from 'typescript';
-
-const TYPESCRIPT_OPTIONS: any = {
-  baseIndentSize: 0,
-  indentSize: 2,
-  tabSize: 2,
-  indentStyle: 2,
-  newLineCharacter: '\n',
-  convertTabsToSpaces: true,
-  insertSpaceAfterCommaDelimiter: true,
-  insertSpaceAfterSemicolonInForStatements: true,
-  insertSpaceBeforeAndAfterBinaryOperators: true,
-  insertSpaceAfterConstructor: false,
-  insertSpaceAfterKeywordsInControlFlowStatements: true,
-  insertSpaceAfterFunctionKeywordForAnonymousFunctions: false,
-  insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,
-  insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
-  insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
-  insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
-  insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
-  insertSpaceAfterTypeAssertion: false,
-  insertSpaceBeforeFunctionParenthesis: false,
-  placeOpenBraceOnNewLineForFunctions: false,
-  placeOpenBraceOnNewLineForControlBlocks: false
-};
-
-const RULE_PROVIDER: any = new (ts as any).formatting.RulesProvider();
-RULE_PROVIDER.ensureUpToDate(TYPESCRIPT_OPTIONS);
-
-const applyEdits: (text: string, edits: ts.TextChange[]) => string = (text, edits) => {
-  let result: string = text;
-  for (let i: number = edits.length - 1; i >= 0; i--) {
-    let change: ts.TextChange = edits[i];
-    result = result.slice(0, change.span.start) + change.newText + result.slice(change.span.start + change.span.length);
-  }
-  return result;
-};
-
+import { format as prettierFormat } from 'prettier';
 const format: (text: string) => string = text => {
-  const sourceFile: ts.SourceFile = ts.createSourceFile('temp.ts', text, ts.ScriptTarget.Latest, true);
-
-  const edits: ts.TextChange[] = (ts as any).formatting.formatDocument(sourceFile, RULE_PROVIDER, TYPESCRIPT_OPTIONS);
-
-  return applyEdits(text, edits);
+  try {
+    // tslint:disable no-require-imports
+    const { format: formatter }: { format: typeof prettierFormat } = require('prettier');
+    return formatter(text, {
+      bracketSpacing: true,
+      parser: 'typescript',
+      semi: true,
+      singleQuote: true,
+      tabWidth: 2,
+      useTabs: false,
+    });
+  } catch (e) {
+    console.warn('To enable pretty-printing, please install prettier');
+    return text;
+  }
 };
 
 export default format;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,6 +2519,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"


### PR DESCRIPTION
fixes #133 and addresses #131/#132

with this pull request, we remove the use of the (private) typescript APIs used to format the code. we, instead, allow the (optional) use of prettier.