### PR TITLE
Default value as an object cause error

### DIFF
--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -39,6 +39,13 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a descripti
    */"
 `;
 
+exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with default values with default value as an object`] = `
+"
+  /**
+   * @default {"number":1,"string":"string"}
+   */"
+`;
+
 exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a description without tags 1`] = `""`;
 
 exports[`language-typescript DEFAULT_ENUM_FORMATTER w/ deprecated value 1`] = `

--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -39,7 +39,7 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a descripti
    */"
 `;
 
-exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with default values with default value as an object`] = `
+exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with default values with 1 default value as an object 1`] = `
 "
   /**
    * @default {"number":1,"string":"string"}

--- a/packages/language-typescript/src/__tests__/index-test.ts
+++ b/packages/language-typescript/src/__tests__/index-test.ts
@@ -150,5 +150,14 @@ describe('language-typescript', () => {
         })).toMatchSnapshot();
       });
     });
+
+    describe('with default values', () => {
+      it('with default value as an object', () => {
+        expect(DEFAULT_DOCUMENTATION_GENERATOR({
+            description: 'This is a thing',
+            tags: [{tag: 'default', value: JSON.stringify({number: 1, string: "string"})}]
+        })).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/packages/language-typescript/src/index.ts
+++ b/packages/language-typescript/src/index.ts
@@ -89,7 +89,7 @@ const fixDescriptionDocblock: (description?: string) => string | undefined = des
 
 export const DEFAULT_DOCUMENTATION_GENERATOR: GenerateDocumentation = ({ description, tags = [] }) => (description || tags.length) ? `
   /**
-   * ${filterAndJoinArray([fixDescriptionDocblock(description), ...tags.map(({ tag, value }) => `@${tag} ${value}`)], '\n* ')}
+   * ${filterAndJoinArray([fixDescriptionDocblock(description), ...tags.map(({ tag, value }) => `@${tag} ${JSON.stringify(value)}`)], '\n* ')}
    */` : '';
 
 export const DEFAULT_OPTIONS: IFromQueryOptions = {

--- a/packages/language-typescript/src/index.ts
+++ b/packages/language-typescript/src/index.ts
@@ -89,7 +89,7 @@ const fixDescriptionDocblock: (description?: string) => string | undefined = des
 
 export const DEFAULT_DOCUMENTATION_GENERATOR: GenerateDocumentation = ({ description, tags = [] }) => (description || tags.length) ? `
   /**
-   * ${filterAndJoinArray([fixDescriptionDocblock(description), ...tags.map(({ tag, value }) => `@${tag} ${JSON.stringify(value)}`)], '\n* ')}
+   * ${filterAndJoinArray([fixDescriptionDocblock(description), ...tags.map(({ tag, value }) => `@${tag} ${typeof value === 'object' ? JSON.stringify(value) : value}`)], '\n* ')}
    */` : '';
 
 export const DEFAULT_OPTIONS: IFromQueryOptions = {


### PR DESCRIPTION
When GraphQL schema provides an object as a default value DEFAULT_DOCUMENTATION_GENERATOR throws error "cannot covert object to primitive value'. I've added JSON.stringify for that behavior.