### PR TITLE
Fix object in default tag

### DIFF
--- a/__tests__/__snapshots__/from-schema-test.ts.snap
+++ b/__tests__/__snapshots__/from-schema-test.ts.snap
@@ -11241,7 +11241,7 @@ humanOrDroid: HumanOrDroid | null;
 getCharacters: Array<Character>;
 
 /**
- * @deprecated Field No Longer Available.
+ * @deprecated \\"Field No Longer Available.\\"
  */
 anOldField: string | null;
 }
@@ -11280,7 +11280,7 @@ friends: Array<Character> | null;
 appearsIn: Array<Episode> | null;
 
 /**
- * @deprecated Field No Longer Available.
+ * @deprecated \\"Field No Longer Available.\\"
  */
 anOldField: string | null;
 nonNullArr: Array<Character>;
@@ -11303,7 +11303,7 @@ appearsIn: Array<Episode> | null;
 homePlanet: string | null;
 
 /**
- * @deprecated Field No Longer Available.
+ * @deprecated \\"Field No Longer Available.\\"
  */
 anOldField: string | null;
 nonNullArr: Array<Character>;
@@ -11321,7 +11321,7 @@ primaryFunction: string | null;
 primaryFunctionNonNull: string;
 
 /**
- * @deprecated Field No Longer Available.
+ * @deprecated \\"Field No Longer Available.\\"
  */
 anOldField: string | null;
 nonNullArr: Array<Character>;

--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -9,6 +9,14 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description 
    */"
 `;
 
+exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description with 1 json tag 1`] = `
+"
+  /**
+   * This is a thing
+* @default {\\"myDefault\\":\\"Value\\"}
+   */"
+`;
+
 exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description with 1 tag 1`] = `
 "
   /**
@@ -29,6 +37,13 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a descripti
   /**
    * @default myDefaultValue
 * @deprecated Use the other field instead
+   */"
+`;
+
+exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a description with 1 json tag 1`] = `
+"
+  /**
+   * @default {\\"myDefault\\":\\"Value\\"}
    */"
 `;
 

--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -4,8 +4,8 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description 
 "
   /**
    * This is a thing
-* @default myDefaultValue
-* @deprecated Use the other field instead
+   * @default myDefaultValue
+   * @deprecated Use the other field instead
    */"
 `;
 
@@ -13,7 +13,7 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description 
 "
   /**
    * This is a thing
-* @default {\\"myDefault\\":\\"Value\\"}
+   * @default {\\"myDefault\\":\\"Value\\"}
    */"
 `;
 
@@ -21,7 +21,7 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description 
 "
   /**
    * This is a thing
-* @default myDefaultValue
+   * @default myDefaultValue
    */"
 `;
 
@@ -36,7 +36,7 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a descripti
 "
   /**
    * @default myDefaultValue
-* @deprecated Use the other field instead
+   * @deprecated Use the other field instead
    */"
 `;
 
@@ -61,7 +61,7 @@ exports[`language-typescript DEFAULT_ENUM_FORMATTER w/ deprecated value 1`] = `
   
   /**
    * value A
-* @deprecated Bad
+   * @deprecated Bad
    */
 a = 'a',
 

--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -4,8 +4,8 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description 
 "
   /**
    * This is a thing
-   * @default myDefaultValue
-   * @deprecated Use the other field instead
+   * @default \\"myDefaultValue\\"
+   * @deprecated \\"Use the other field instead\\"
    */"
 `;
 
@@ -21,7 +21,7 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description 
 "
   /**
    * This is a thing
-   * @default myDefaultValue
+   * @default \\"myDefaultValue\\"
    */"
 `;
 
@@ -35,8 +35,8 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR with a description 
 exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a description with >1 tag 1`] = `
 "
   /**
-   * @default myDefaultValue
-   * @deprecated Use the other field instead
+   * @default \\"myDefaultValue\\"
+   * @deprecated \\"Use the other field instead\\"
    */"
 `;
 
@@ -50,7 +50,7 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a descripti
 exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a description with 1 tag 1`] = `
 "
   /**
-   * @default myDefaultValue
+   * @default \\"myDefaultValue\\"
    */"
 `;
 
@@ -61,12 +61,12 @@ exports[`language-typescript DEFAULT_ENUM_FORMATTER w/ deprecated value 1`] = `
   
   /**
    * value A
-   * @deprecated Bad
+   * @deprecated \\"Bad\\"
    */
 a = 'a',
 
   /**
-   * @deprecated Bad
+   * @deprecated \\"Bad\\"
    */
 b = 'b',
 

--- a/packages/language-typescript/src/__tests__/index-test.ts
+++ b/packages/language-typescript/src/__tests__/index-test.ts
@@ -119,6 +119,12 @@ describe('language-typescript', () => {
           tags: [{ tag: 'default', value: 'myDefaultValue' }]
         })).toMatchSnapshot();
       });
+      it('with 1 json tag', () => {
+        expect(DEFAULT_DOCUMENTATION_GENERATOR({
+          description: 'This is a thing',
+          tags: [{ tag: 'default', value: { myDefault: 'Value' } }]
+        })).toMatchSnapshot();
+      });
       it('with >1 tag', () => {
         expect(DEFAULT_DOCUMENTATION_GENERATOR({
           description: 'This is a thing',
@@ -139,6 +145,11 @@ describe('language-typescript', () => {
       it('with 1 tag', () => {
         expect(DEFAULT_DOCUMENTATION_GENERATOR({
           tags: [{ tag: 'default', value: 'myDefaultValue' }]
+        })).toMatchSnapshot();
+      });
+      it('with 1 json tag', () => {
+        expect(DEFAULT_DOCUMENTATION_GENERATOR({
+          tags: [{ tag: 'default', value: { myDefault: 'Value' } }]
         })).toMatchSnapshot();
       });
       it('with >1 tag', () => {

--- a/packages/language-typescript/src/index.ts
+++ b/packages/language-typescript/src/index.ts
@@ -87,9 +87,11 @@ ${interfaces}
 const fixDescriptionDocblock: (description?: string) => string | undefined = description =>
   description ? description.replace(/\n/g, '\n* ') : description;
 
+const _printValue = value => typeof value === 'object' ? JSON.stringify(value) : value;
+
 export const DEFAULT_DOCUMENTATION_GENERATOR: GenerateDocumentation = ({ description, tags = [] }) => (description || tags.length) ? `
   /**
-   * ${filterAndJoinArray([fixDescriptionDocblock(description), ...tags.map(({ tag, value }) => `@${tag} ${value}`)], '\n* ')}
+   * ${filterAndJoinArray([fixDescriptionDocblock(description), ...tags.map(({ tag, value }) => `@${tag} ${_printValue(value)}`)], '\n* ')}
    */` : '';
 
 export const DEFAULT_OPTIONS: IFromQueryOptions = {

--- a/packages/language-typescript/src/index.ts
+++ b/packages/language-typescript/src/index.ts
@@ -93,8 +93,7 @@ export const DEFAULT_DOCUMENTATION_GENERATOR: GenerateDocumentation = ({ descrip
   }
   const arr: Array<string | undefined> = [
     fixDescriptionDocblock(description),
-    ...tags.map(({ tag, value }) =>
-      `@${tag} ${typeof value === 'object' ? JSON.stringify(value) : value}`)
+    ...tags.map(({ tag, value }) => `@${tag} ${JSON.stringify(value)}`)
   ];
   return `
   /**

--- a/packages/language-typescript/src/index.ts
+++ b/packages/language-typescript/src/index.ts
@@ -87,12 +87,20 @@ ${interfaces}
 const fixDescriptionDocblock: (description?: string) => string | undefined = description =>
   description ? description.replace(/\n/g, '\n* ') : description;
 
-const _printValue = value => typeof value === 'object' ? JSON.stringify(value) : value;
-
-export const DEFAULT_DOCUMENTATION_GENERATOR: GenerateDocumentation = ({ description, tags = [] }) => (description || tags.length) ? `
+export const DEFAULT_DOCUMENTATION_GENERATOR: GenerateDocumentation = ({ description, tags = [] }) => {
+  if (!description && !tags.length) {
+    return '';
+  }
+  const arr: Array<string | undefined> = [
+    fixDescriptionDocblock(description),
+    ...tags.map(({ tag, value }) =>
+      `@${tag} ${typeof value === 'object' ? JSON.stringify(value) : value}`)
+  ];
+  return `
   /**
-   * ${filterAndJoinArray([fixDescriptionDocblock(description), ...tags.map(({ tag, value }) => `@${tag} ${_printValue(value)}`)], '\n* ')}
-   */` : '';
+   * ${filterAndJoinArray(arr, '\n   * ')}
+   */`;
+};
 
 export const DEFAULT_OPTIONS: IFromQueryOptions = {
   wrapList: DEFAULT_WRAP_LIST,

--- a/packages/util/src/parser.ts
+++ b/packages/util/src/parser.ts
@@ -7,7 +7,7 @@ import {
 
 export interface IJSDocTag {
   tag: string;
-  value: string;
+  value: string | Object;
 }
 
 export interface IFieldDocumentation {

--- a/packages/util/src/parser.ts
+++ b/packages/util/src/parser.ts
@@ -7,7 +7,7 @@ import {
 
 export interface IJSDocTag {
   tag: string;
-  value: string | Object;
+  value: string | object;
 }
 
 export interface IFieldDocumentation {


### PR DESCRIPTION
This PR fixes 2 issues:

- Default generator crashing when using objects as defaults (see example below).
- Default spacing were inconsistent with everything else.

Example: In our API we've got something like:

```graphql
users(
  query: String,
  orderBy: UserOrder = {field: creation_time, direction: ASC}
): [User!]!
```

However, using gql2ts breaks when trying to convert that, since `orderBy` is an object. This seems to fix it, although I'm not sure it's the best way to deal with it.