### PR TITLE
Enum as const so it can be used, don't add semicolon as it is invalid TS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## master
+
+- Export enums as consts in `@gql2ts/from-schema` so they are available to the Typescript compiler. [Issue #179](https://github.com/avantcredit/gql2ts/issues/179) [PR #202](https://github.com/avantcredit/gql2ts/pull/202)
+
+- Only append a semicolon to 'enums' when they are declared as union types and not Typescript `enum` types. [Issue #179](https://github.com/avantcredit/gql2ts/issues/179) [PR #202](https://github.com/avantcredit/gql2ts/pull/202)
+
 ## 1.8.0
 
 - Add specific `__typename` value for `@gql2ts/from-query` [Issue #165](https://github.com/avantcredit/gql2ts/issues/165) [PR #168](https://github.com/avantcredit/gql2ts/pull/168)

--- a/__tests__/__snapshots__/from-query-normalSchema-test.ts.snap
+++ b/__tests__/__snapshots__/from-query-normalSchema-test.ts.snap
@@ -769,7 +769,7 @@ export interface EnumQuery {
   },
   Object {
     "additionalTypes": Array [
-      "export enum Episode {
+      "export const enum Episode {
   NEWHOPE = 'NEWHOPE',
   EMPIRE = 'EMPIRE',
   JEDI = 'JEDI'
@@ -777,7 +777,7 @@ export interface EnumQuery {
 ",
     ],
     "interface": "",
-    "result": "export enum Episode {
+    "result": "export const enum Episode {
   NEWHOPE = 'NEWHOPE',
   EMPIRE = 'EMPIRE',
   JEDI = 'JEDI'

--- a/__tests__/__snapshots__/from-schema-test.ts.snap
+++ b/__tests__/__snapshots__/from-schema-test.ts.snap
@@ -1955,11 +1955,11 @@ nonNullArrAndContents: Array<Character>;
 nullArrNonNullContents: Array<Character>;
 }
 
-enum Episode {
+const enum Episode {
 NEWHOPE = 'NEWHOPE',
 EMPIRE = 'EMPIRE',
 JEDI = 'JEDI'
-};
+}
 
 interface IHuman {
 __typename: \\"Human\\";
@@ -3706,11 +3706,11 @@ __typename: \\"Query\\";
 colorEnum: Color | null;
 }
 
-enum Color {
+const enum Color {
 RED = 'RED',
 GREEN = 'GREEN',
 BLUE = 'BLUE'
-};"
+}"
 `;
 
 exports[`gql2ts interfaces correctly translates enums with types 1`] = `
@@ -7607,7 +7607,7 @@ declare namespace GQL {
     colorEnum: Color | null;
   }
 
-  enum Color {
+  const enum Color {
     RED = 'RED',
     GREEN = 'GREEN',
     BLUE = 'BLUE'
@@ -11288,11 +11288,11 @@ nonNullArrAndContents: Array<Character>;
 nullArrNonNullContents: Array<Character>;
 }
 
-enum Episode {
+const enum Episode {
 NEWHOPE = 'NEWHOPE',
 EMPIRE = 'EMPIRE',
 JEDI = 'JEDI'
-};
+}
 
 interface IHuman {
 __typename: \\"Human\\";

--- a/packages/from-query/__tests__/__snapshots__/from-query-test.ts.snap
+++ b/packages/from-query/__tests__/__snapshots__/from-query-test.ts.snap
@@ -343,7 +343,7 @@ export interface Anonymous {
   },
   Object {
     "additionalTypes": Array [
-      "export enum TypeKind {
+      "export const enum TypeKind {
   /**
    * Indicates this type is a scalar.
    */
@@ -387,7 +387,7 @@ export interface Anonymous {
 ",
     ],
     "interface": "",
-    "result": "export enum TypeKind {
+    "result": "export const enum TypeKind {
   /**
    * Indicates this type is a scalar.
    */
@@ -681,7 +681,7 @@ export interface IFragmentTypeRef {
   },
   Object {
     "additionalTypes": Array [
-      "export enum DirectiveLocation {
+      "export const enum DirectiveLocation {
   /**
    * Location adjacent to a query operation.
    */
@@ -773,7 +773,7 @@ export interface IFragmentTypeRef {
   INPUT_FIELD_DEFINITION = 'INPUT_FIELD_DEFINITION'
 }
 ",
-      "export enum TypeKind {
+      "export const enum TypeKind {
   /**
    * Indicates this type is a scalar.
    */
@@ -817,7 +817,7 @@ export interface IFragmentTypeRef {
 ",
     ],
     "interface": "",
-    "result": "export enum DirectiveLocation {
+    "result": "export const enum DirectiveLocation {
   /**
    * Location adjacent to a query operation.
    */
@@ -909,7 +909,7 @@ export interface IFragmentTypeRef {
   INPUT_FIELD_DEFINITION = 'INPUT_FIELD_DEFINITION'
 }
 
-export enum TypeKind {
+export const enum TypeKind {
   /**
    * Indicates this type is a scalar.
    */

--- a/packages/from-schema/src/index.ts
+++ b/packages/from-schema/src/index.ts
@@ -147,10 +147,20 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
       );
     }
 
+    // Becuase enums when declared do not end in semicolons and types do
+    // the we wrap the format enum function depending on if we are using the
+    // type builder or the enum type number
+    const wrappedEnumFormatFunction: () => string = function (): string {
+      if (!enumTypeBuilder) {
+        return addSemicolon(formatEnum(enumValues, generateDocumentation));
+      }
+      return formatEnum(enumValues, generateDocumentation);
+    };
+
     return wrapWithDocumentation(
       (enumTypeBuilder || typeBuilder)(
         generateEnumName(name),
-        formatEnum(enumValues, generateDocumentation)
+        wrappedEnumFormatFunction()
       ),
       { description, tags: [] }
     );

--- a/packages/from-schema/src/index.ts
+++ b/packages/from-schema/src/index.ts
@@ -119,7 +119,7 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
     (description, name, possibleTypes) => wrapWithDocumentation(
       addSemicolon(typeBuilder(name, possibleTypes)),
       { description, tags: [] }
-    )  + '\n\n';
+    ) + '\n\n';
 
   const typeNameDeclaration: (name: string) => string = name => addSemicolon(`__typename: "${name}"`);
 
@@ -129,7 +129,7 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
   const generateInterfaceDeclaration: GenerateInterfaceDeclaration =
     ({ name, description }, declaration, fields, additionalInfo, isInput) => {
       if (!isInput && !optionsInput.ignoreTypeNameDeclaration) {
-       fields =  [typeNameDeclaration(name), ...fields];
+        fields = [typeNameDeclaration(name), ...fields];
       }
 
       return additionalInfo + wrapWithDocumentation(
@@ -147,20 +147,12 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
       );
     }
 
-    // Becuase enums when declared do not end in semicolons and types do
-    // the we wrap the format enum function depending on if we are using the
-    // type builder or the enum type number
-    const wrappedEnumFormatFunction: () => string = function (): string {
-      if (!enumTypeBuilder) {
-        return addSemicolon(formatEnum(enumValues, generateDocumentation));
-      }
-      return formatEnum(enumValues, generateDocumentation);
-    };
-
+    const formattedEnum: string = formatEnum(enumValues, generateDocumentation);
     return wrapWithDocumentation(
       (enumTypeBuilder || typeBuilder)(
         generateEnumName(name),
-        wrappedEnumFormatFunction()
+        // Only add semicolon when not using enum type builder
+        enumTypeBuilder ? formattedEnum : addSemicolon(formattedEnum)
       ),
       { description, tags: [] }
     );
@@ -299,7 +291,7 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
 
     const fields: string[] = filteredFields
       .map(field => [generateDocumentation(buildDocumentation(field)), fieldToDefinition(field, isInput, supportsNullability)])
-      .reduce((acc, val) => [...acc, ...val] , [])
+      .reduce((acc, val) => [...acc, ...val], [])
       .filter(Boolean);
 
     const interfaceDeclaration: string = generateInterfaceName(type.name);

--- a/packages/from-schema/src/index.ts
+++ b/packages/from-schema/src/index.ts
@@ -150,9 +150,7 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
     return wrapWithDocumentation(
       (enumTypeBuilder || typeBuilder)(
         generateEnumName(name),
-        addSemicolon(
-          formatEnum(enumValues, generateDocumentation)
-        )
+        formatEnum(enumValues, generateDocumentation)
       ),
       { description, tags: [] }
     );

--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -81,7 +81,7 @@ e = 'e'
 
 exports[`language-typescript DEFAULT_ENUM_FORMATTER w/ description 1`] = `
 "{
-
+  
   /**
    * value A
    */

--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -58,7 +58,7 @@ exports[`language-typescript DEFAULT_DOCUMENTATION_GENERATOR without a descripti
 
 exports[`language-typescript DEFAULT_ENUM_FORMATTER w/ deprecated value 1`] = `
 "{
-
+  
   /**
    * value A
    * @deprecated \\"Bad\\"

--- a/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/language-typescript/src/__tests__/__snapshots__/index-test.ts.snap
@@ -98,7 +98,7 @@ b = 'b'
 `;
 
 exports[`language-typescript DEFAULT_ENUM_TYPE_BUILDER formats properly 1`] = `
-"enum Test {
+"const enum Test {
   a = 'a',
 b = 'b'
 }"

--- a/packages/language-typescript/src/index.ts
+++ b/packages/language-typescript/src/index.ts
@@ -67,7 +67,7 @@ export const DEFAULT_ENUM_FORMATTER: EnumFormatter = (values, documentationGener
 }`;
 
 export const DEFAULT_ENUM_TYPE_BUILDER: EnumTypeBuilder = (name, values) =>
-`enum ${name} ${values}`;
+`const enum ${name} ${values}`;
 
 export const DEFAULT_ENUM_NAME_GENERATOR: WrapType = name => `${pascalize(name)}`;
 export const DEFAULT_INPUT_NAME_GENERATOR: WrapType = name => `${pascalize(name)}Input`;


### PR DESCRIPTION
This makes two changes to make the update to using enums functional. 

1) Removes the errant semicolon that is added to the type declaration.
2) Declares `enum` as a `const` so it is available to the typescript compiler. 