### PR TITLE
Fix default typemap

### DIFF
--- a/__tests__/__snapshots__/from-schema-test.ts.snap
+++ b/__tests__/__snapshots__/from-schema-test.ts.snap
@@ -11211,6 +11211,129 @@ declare namespace StarWars {
 "
 `;
 
+exports[`gql2ts scalar supports typemap 1`] = `
+"interface IGraphQLResponseRoot {
+data?: IQuery;
+errors?: Array<IGraphQLResponseError>;
+}
+
+interface IGraphQLResponseError {
+/** Required for all errors */
+message: string;
+locations?: Array<IGraphQLResponseErrorLocation>;
+/** 7.2.2 says 'GraphQL servers may provide additional entries to error' */
+[propName: string]: any;
+}
+
+interface IGraphQLResponseErrorLocation {
+line: number;
+column: number;
+}
+
+interface IQuery {
+__typename: \\"Query\\";
+heroNoParam: Character | null;
+hero: Character | null;
+human: IHuman | null;
+droid: IDroid | null;
+test: TestScalar | null;
+humanOrDroid: HumanOrDroid | null;
+getCharacters: Array<Character | null>;
+
+/**
+ * @deprecated \\"Field No Longer Available.\\"
+ */
+anOldField: string | null;
+}
+
+interface IHeroOnQueryArguments {
+episode?: Episode | null;
+}
+
+interface IHumanOnQueryArguments {
+id: string;
+}
+
+interface IDroidOnQueryArguments {
+id: string;
+}
+
+interface ITestOnQueryArguments {
+test?: TestScalar | null;
+}
+
+interface IHumanOrDroidOnQueryArguments {
+id: string;
+}
+
+interface IGetCharactersOnQueryArguments {
+ids: Array<string>;
+}
+
+type Character = IHuman | IDroid;
+
+interface ICharacter {
+__typename: \\"Character\\";
+id: string;
+name: string | null;
+friends: Array<Character | null> | null;
+appearsIn: Array<Episode | null> | null;
+
+/**
+ * @deprecated \\"Field No Longer Available.\\"
+ */
+anOldField: string | null;
+nonNullArr: Array<Character | null>;
+nonNullArrAndContents: Array<Character>;
+nullArrNonNullContents: Array<Character> | null;
+}
+
+const enum Episode {
+NEWHOPE = 'NEWHOPE',
+EMPIRE = 'EMPIRE',
+JEDI = 'JEDI'
+}
+
+interface IHuman {
+__typename: \\"Human\\";
+id: string;
+name: string | null;
+friends: Array<Character | null> | null;
+appearsIn: Array<Episode | null> | null;
+homePlanet: string | null;
+
+/**
+ * @deprecated \\"Field No Longer Available.\\"
+ */
+anOldField: string | null;
+nonNullArr: Array<Character | null>;
+nonNullArrAndContents: Array<Character>;
+nullArrNonNullContents: Array<Character> | null;
+}
+
+interface IDroid {
+__typename: \\"Droid\\";
+id: string;
+name: string | null;
+friends: Array<Character | null> | null;
+appearsIn: Array<Episode | null> | null;
+primaryFunction: string | null;
+primaryFunctionNonNull: string;
+
+/**
+ * @deprecated \\"Field No Longer Available.\\"
+ */
+anOldField: string | null;
+nonNullArr: Array<Character | null>;
+nonNullArrAndContents: Array<Character>;
+nullArrNonNullContents: Array<Character> | null;
+}
+
+type HumanOrDroid = IHuman | IDroid;
+
+"
+`;
+
 exports[`gql2ts union types correctly translates the schema into typescript defs 1`] = `
 "interface IGraphQLResponseRoot {
 data?: IQuery;

--- a/__tests__/from-schema-test.ts
+++ b/__tests__/from-schema-test.ts
@@ -1,5 +1,5 @@
 import { schemaToInterfaces, generateNamespace } from '../packages/from-schema/src';
-import { DEFAULT_OPTIONS } from '../packages/language-typescript/src';
+import { DEFAULT_OPTIONS, DEFAULT_TYPE_MAP } from '../packages/language-typescript/src';
 import schema from './data/starWarsSchema';
 import enumSchema from './data/enumSchema';
 import simpleSchema from './shared/simpleSchema';
@@ -110,6 +110,19 @@ describe('gql2ts', () => {
       const actual: string = schemaToInterfaces(simpleSchema, {
         ignoredTypes: [],
         excludeDeprecatedFields: true
+      });
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('scalar', () => {
+    it('supports typemap', () => {
+      const actual: string = schemaToInterfaces(simpleSchema, {
+        ignoredTypes: [],
+        typeMap: {
+          ...DEFAULT_TYPE_MAP,
+          TestScalar: 'TestScalar'
+        }
       });
       expect(actual).toMatchSnapshot();
     });

--- a/packages/from-schema/src/index.ts
+++ b/packages/from-schema/src/index.ts
@@ -185,7 +185,7 @@ const run: (schemaInput: GraphQLSchema, optionsInput: IInternalOptions) => strin
     }
     if (isScalar(type)) {
       return {
-        value: DEFAULT_TYPE_MAP[type.name] || DEFAULT_TYPE_MAP.__DEFAULT,
+        value: TYPE_MAP[type.name] || TYPE_MAP.__DEFAULT,
         isList: false,
         isNonNull
       };


### PR DESCRIPTION
Fixes https://github.com/avantcredit/gql2ts/issues/233

The previously added feature to support nullable arrays, nesting etc. broke custom type maps as we were using `DEFAULT_TYPE_MAP` instead of just `TYPE_MAP`. This has now been fixed and a test to make sure it works correctly was added as well.