### PR TITLE
Allow undefined for nullable types

### DIFF
--- a/packages/language-typescript/src/index.ts
+++ b/packages/language-typescript/src/index.ts
@@ -52,7 +52,7 @@ export const DEFAULT_TYPE_MAP: ITypeMap = {
 export const DEFAULT_WRAP_LIST: WrapType = type => `Array<${type}>`;
 export const DEFAULT_WRAP_PARTIAL: WrapType = partial => `Partial<${partial}>`;
 
-export const DEFAULT_TYPE_PRINTER: TypePrinter = (type, isNonNull) => isNonNull ? type : `${type} | null`;
+export const DEFAULT_TYPE_PRINTER: TypePrinter = (type, isNonNull) => isNonNull ? type : `${type} | null | undefined`;
 
 export const DEFAULT_GENERATE_SUBTYPE_INTERFACE_NAME: GenerateSubTypeInterface = selectionName => `SelectionOn${pascalize(selectionName)}`;
 


### PR DESCRIPTION
This allows omitting the key entirely from objects, instead of having to specify a null key.

Example:

```
return {
  error: null,
  user: { ... }
}
```

But it's handier to allow undefined values as well:

```
return {
  user: { ... }
}
```